### PR TITLE
chore: add `break-all` if the title of the header in the sidebar is URL

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -369,7 +369,7 @@ function SideBarHeader({ children }: { children: Child<string> }) {
     return (
       <div>
         <h2 class={tw`text-gray-900 text-2xl font-bold`}>
-          <a href={href} class={tw`hover:underline`}>{label}</a>
+          <a href={href} class={tw`hover:underline break-all`}>{label}</a>
         </h2>
         {version && (
           <div>


### PR DESCRIPTION
Add line breaks to the sidebar headers to make them look good.

for example:
- https://doc.deno.land/https://cdn.esm.sh/v58/firebase@9.4.1/database/dist/database/index.d.ts
- https://doc.deno.land/https://github.com/denoland/deno_std/raw/main/http/mod.ts

before:
![image](https://user-images.githubusercontent.com/40050810/144709481-b4d76a34-b19b-4f83-bbc7-d1ddf9cecb9a.png)

after:
![image](https://user-images.githubusercontent.com/40050810/144709494-e2a98fb6-fced-453b-804f-861093ba56a3.png)

