### PR TITLE
fix: namespaced type refs resolve

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -223,7 +223,8 @@ function DocToc({ children }: { children: Child<DocNode[]> }) {
 export function DocPage(
   { children, base }: { children: Child<string | null | undefined>; base: URL },
 ) {
-  const { entries, url, includePrivate } = store.state as StoreState;
+  const state = store.state as StoreState;
+  const { entries, url, includePrivate } = state;
   const collection = asCollection(entries, includePrivate);
   const library = url.startsWith("deno:");
   const item = take(children);
@@ -232,14 +233,18 @@ export function DocPage(
     const name = path.pop()!;
     let { entries, url } = store.state as StoreState;
     if (path && path.length) {
+      const namespaces = [];
       for (const name of path) {
         const namespace = entries.find((n) =>
           n.kind === "namespace" && n.name === name
         ) as DocNodeNamespace | undefined;
         if (namespace) {
+          namespaces.push(namespace);
           entries = namespace.namespaceDef.elements;
         }
       }
+      state.namespaces = namespaces;
+      store.setState(state);
     }
     const nodes = entries.filter((e) => e.name === name && e.kind !== "import");
     if (!nodes.length) {

--- a/components/jsdoc_test.tsx
+++ b/components/jsdoc_test.tsx
@@ -1,4 +1,6 @@
-/* @jsx h */
+// Copyright 2021 the Deno authors. All rights reserved. MIT license.
+
+/** @jsx h */
 import { h, renderSSR } from "../deps.ts";
 import type { JsDocTagDoc } from "../deps.ts";
 import { assertEquals } from "../deps_test.ts";

--- a/components/types_test.tsx
+++ b/components/types_test.tsx
@@ -1,0 +1,78 @@
+// Copyright 2021 the Deno authors. All rights reserved. MIT license.
+
+/** @jsx h */
+import { h, renderSSR } from "../deps.ts";
+import type { TsTypeTypeRefDef } from "../deps.ts";
+import { assertEquals } from "../deps_test.ts";
+import { sheet, store } from "../shared.ts";
+import type { StoreState } from "../shared.ts";
+
+import { TypeDef } from "./types.tsx";
+
+Deno.test({
+  name: "TypeDef - namespaced peer",
+  fn() {
+    const state: StoreState = {
+      entries: [{
+        kind: "variable",
+        name: "C",
+        location: {
+          filename: "https://deno.land/x/example/mod.ts",
+          line: 1,
+          col: 0,
+        },
+        variableDef: {
+          kind: "const",
+        },
+        declarationKind: "export",
+      }],
+      namespaces: [{
+        kind: "namespace",
+        namespaceDef: {
+          elements: [{
+            kind: "variable",
+            name: "C",
+            location: {
+              filename: "https://deno.land/x/example/mod.ts",
+              line: 3,
+              col: 0,
+            },
+            variableDef: {
+              kind: "const",
+            },
+            declarationKind: "export",
+          }],
+        },
+        name: "A",
+        location: {
+          filename: "https://deno.land/x/example/mod.ts",
+          line: 2,
+          col: 0,
+        },
+        declarationKind: "export",
+      }],
+      url: "https://deno.land/x/example/mod.ts",
+      includePrivate: false,
+    };
+    store.setState(state);
+    const Expected = () => (
+      <span>
+        <a href="/https://deno.land/x/example/mod.ts/~/A.C" class="tw-1h2u08d">
+          C
+        </a>
+      </span>
+    );
+    const def: TsTypeTypeRefDef = {
+      kind: "typeRef",
+      repr: "",
+      typeRef: {
+        typeName: "C",
+      },
+    };
+    sheet.reset();
+    const actual = renderSSR(<TypeDef inline>{def}</TypeDef>)
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected></Expected>).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});

--- a/shared.ts
+++ b/shared.ts
@@ -9,16 +9,18 @@ import {
   twColors,
   virtualSheet,
 } from "./deps.ts";
-import type { DocNode } from "./deps.ts";
+import type { DocNode, DocNodeNamespace } from "./deps.ts";
 
 export const store = new Store({
   entries: [],
+  namespaces: [],
   url: "",
   includePrivate: false,
 });
 
 export interface StoreState {
   entries: DocNode[];
+  namespaces: DocNodeNamespace[];
   url: string;
   includePrivate: boolean;
 }

--- a/test.ts
+++ b/test.ts
@@ -59,7 +59,11 @@ Deno.test({
     // validate that builtin doc nodes get merged properly
     res = await fetch(`${server}deno/stable/~/Deno.connect`);
     assertEquals(res.status, 200);
-    assertStringIncludes(await res.text(), ">Deno.connect<");
+    const text = await res.text();
+    assertStringIncludes(text, ">Deno.connect<");
+
+    // validate that namespaced type references are resolved
+    assertStringIncludes(text, `href="/deno/stable/~/Deno.Conn"`);
 
     // doc query URLs are redirected to perm-link
     res = await fetch(


### PR DESCRIPTION
Now, a type reference from something like `Deno.connect` to `Deno.Conn` provides a link. Previously, it would not have resolved a link to the type reference.

Fixes #25 