### PR TITLE
feat: flatten namespaces on index pages

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -46,7 +46,7 @@ function ModuleToc(
 ) {
   const collection = take(children);
   const imports = collection.import
-    ? collection.import.map((imp) => <li>{imp.importDef.src}</li>)
+    ? collection.import.map(([, imp]) => <li>{imp.importDef.src}</li>)
     : undefined;
   return (
     <div>
@@ -81,7 +81,7 @@ function DocNodes({ children }: { children: Child<DocNodeCollection> }) {
     <div class={gtw("mainBox")}>
       {collection.moduleDoc && (
         <JsDoc style={largeMarkdownStyles}>
-          {collection.moduleDoc[0].jsDoc}
+          {collection.moduleDoc[0][1].jsDoc}
         </JsDoc>
       )}
       {collection.namespace && (
@@ -225,7 +225,7 @@ export function DocPage(
 ) {
   const state = store.state as StoreState;
   const { entries, url, includePrivate } = state;
-  const collection = asCollection(entries, includePrivate);
+  const collection = asCollection(entries, undefined, includePrivate);
   const library = url.startsWith("deno:");
   const item = take(children);
   if (item) {

--- a/components/namespaces.tsx
+++ b/components/namespaces.tsx
@@ -16,42 +16,45 @@ export function NamespaceDoc(
   const node = take(children);
   const { name, namespaceDef: { elements } } = node;
   const { includePrivate } = store.state as StoreState;
-  const collection = asCollection(elements, includePrivate);
-  const currentPath = [...path, name];
+  const collection = asCollection(
+    elements,
+    [...path, name].join("."),
+    includePrivate,
+  );
   return (
     <div>
       {collection.namespace && (
-        <Section title="Namespace" style="nodeNamespace" path={currentPath}>
+        <Section title="Namespace" style="nodeNamespace">
           {collection.namespace}
         </Section>
       )}
       {collection.class && (
-        <Section title="Classes" style="nodeClass" path={currentPath}>
+        <Section title="Classes" style="nodeClass">
           {collection.class}
         </Section>
       )}
       {collection.enum && (
-        <Section title="Enums" style="nodeEnum" path={currentPath}>
+        <Section title="Enums" style="nodeEnum">
           {collection.enum}
         </Section>
       )}
       {collection.variable && (
-        <Section title="Variables" style="nodeVariable" path={currentPath}>
+        <Section title="Variables" style="nodeVariable">
           {collection.variable}
         </Section>
       )}
       {collection.function && (
-        <Section title="Functions" style="nodeFunction" path={currentPath}>
+        <Section title="Functions" style="nodeFunction">
           {collection.function}
         </Section>
       )}
       {collection.interface && (
-        <Section title="Interfaces" style="nodeInterface" path={currentPath}>
+        <Section title="Interfaces" style="nodeInterface">
           {collection.interface}
         </Section>
       )}
       {collection.typeAlias && (
-        <Section title="Type Aliases" style="nodeTypeAlias" path={currentPath}>
+        <Section title="Type Aliases" style="nodeTypeAlias">
           {collection.typeAlias}
         </Section>
       )}
@@ -64,7 +67,7 @@ export function NamespaceToc(
 ) {
   const { name, namespaceDef: { elements } } = take(children);
   const { includePrivate } = store.state as StoreState;
-  const collection = asCollection(elements, includePrivate);
+  const collection = asCollection(elements, undefined, includePrivate);
   return (
     <div>
       <h3 class={gtw("tocHeader")}>

--- a/middleware/badge.ts
+++ b/middleware/badge.ts
@@ -3,7 +3,7 @@ import type { Middleware } from "../deps.ts";
 
 export function createBadgeMW(): Middleware {
   let badge: Uint8Array | undefined;
-  return async function favicon(ctx, next) {
+  return async function badgeMW(ctx, next) {
     if (ctx.request.url.pathname !== "/badge.svg") {
       return next();
     }


### PR DESCRIPTION
Ref #3 

This is part 1 of what I suggested in #3, where namespaces are flattened on the index page, so "all" symbols are listed.

Here is what it looks like for `/deno/stable` now:

<img width="893" alt="Deno_Doc_-_deno_stable_" src="https://user-images.githubusercontent.com/1282577/144772956-d524f1a6-35fe-44dc-931c-c91edfc8b46b.png">

And here is what it looks like for `oak`:

<img width="892" alt="Cursor_and_Deno_Doc_-_https___deno_land_x_oak_mod_ts" src="https://user-images.githubusercontent.com/1282577/144772968-d71a1aee-27ef-4b79-99a1-9e3f0d68bc80.png">

