### PR TITLE
fix: pin deno_doc to commit

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -13,11 +13,11 @@ export * as comrak from "https://deno.land/x/comrak@0.1.1/mod.ts";
 
 // WASM bindings to swc/deno_graph/deno_doc which generates the documentation
 // structures
-export { doc } from "https://raw.githubusercontent.com/denoland/deno_doc/main/mod.ts";
+export { doc } from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/mod.ts";
 export type {
   DocOptions,
   LoadResponse,
-} from "https://raw.githubusercontent.com/denoland/deno_doc/main/mod.ts";
+} from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/mod.ts";
 export type {
   Accessibility,
   ClassConstructorDef,
@@ -88,7 +88,7 @@ export type {
   TsTypeTypePredicateDef,
   TsTypeTypeRefDef,
   TsTypeUnionDef,
-} from "https://raw.githubusercontent.com/denoland/deno_doc/main/lib/types.d.ts";
+} from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/lib/types.d.ts";
 
 // Used when overriding proxies content types when serving up static content
 export { lookup } from "https://deno.land/x/media_types@v2.11.0/mod.ts";


### PR DESCRIPTION
Seems like the upgrade to deno_ast has caused a regression in doc.deno.land on Deploy, so need to pin to a commit.