### PR TITLE
chore: update to deno_doc@v0.22.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -13,11 +13,11 @@ export * as comrak from "https://deno.land/x/comrak@0.1.1/mod.ts";
 
 // WASM bindings to swc/deno_graph/deno_doc which generates the documentation
 // structures
-export { doc } from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/mod.ts";
+export { doc } from "https://deno.land/x/deno_doc@v0.22.0/mod.ts";
 export type {
   DocOptions,
   LoadResponse,
-} from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/mod.ts";
+} from "https://deno.land/x/deno_doc@v0.22.0/mod.ts";
 export type {
   Accessibility,
   ClassConstructorDef,
@@ -88,7 +88,7 @@ export type {
   TsTypeTypePredicateDef,
   TsTypeTypeRefDef,
   TsTypeUnionDef,
-} from "https://raw.githubusercontent.com/denoland/deno_doc/cc14e65aae46c224e3381fc0cb8ad5239b861a6c/lib/types.d.ts";
+} from "https://deno.land/x/deno_doc@v0.22.0/lib/types.d.ts";
 
 // Used when overriding proxies content types when serving up static content
 export { lookup } from "https://deno.land/x/media_types@v2.11.0/mod.ts";


### PR DESCRIPTION
Closes #33

Moving to `https://deno.land/x/deno_doc@v0.22.0/mod.ts` pins the dependency as well as causes a slightly different (more efficient) path to instantiate the WASM module to be used.  Moving back to rawgithub doesn't seem to be able to replicate the issue before, but this version is stable and shouldn't float.  It could have been that having an unpinned raw github caused some sort of problem in Deploy's cache when we made the change, where the WASM was out of sync with the generated JavaScript?