### PR TITLE
feat: responsive design

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -1,13 +1,16 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
-import { h, tw } from "../deps.ts";
-import { gtw } from "./styles.ts";
+import { h, Helmet, tw } from "../deps.ts";
+import { gtw, nav } from "./styles.ts";
 
 export function App({ children }: { children?: unknown }) {
   return (
-    <div class={gtw("app")}>
+    <div class={tw`h-screen bg-white`}>
+      <Helmet>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </Helmet>
       <Header />
-      <div>{children}</div>
+      {children}
       <Footer />
     </div>
   );
@@ -15,39 +18,98 @@ export function App({ children }: { children?: unknown }) {
 
 function Footer() {
   return (
-    <footer class={tw`flex justify-between items-end p-8 pt-32`}>
-      <div class={tw`flex align-center`}>
-        <Logo />
-        <p class={tw`ml-4 font-bold text-xl`}>Deno</p>
-      </div>
-      <div class={tw`flex flex-col lg:flex-row gap-x-8 gap-y-6 text-right`}>
-        <FooterLink href="https://deno.com/deploy">Deploy</FooterLink>
+    <footer
+      class={tw
+        `mt-20 max-w-screen-xl mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8`}
+    >
+      <nav class={tw`-mx-5 -my-2 flex flex-wrap justify-center`}>
         <FooterLink href="https://deno.land/manual">Manual</FooterLink>
-        <FooterLink href="/deno/stable">Runtime API</FooterLink>
+        <FooterLink href="/deno/stable">API</FooterLink>
         <FooterLink href="https://deno.land/std">Standard Library</FooterLink>
         <FooterLink href="https://deno.land/x">Third Party Modules</FooterLink>
+        <FooterLink href="https://deno.land/benchmarks">Benchmarks</FooterLink>
+        <FooterLink href="https://deno.land/artwork">Artwork</FooterLink>
         <FooterLink href="https://deno.com/blog">Blog</FooterLink>
-        <FooterLink href="https://deno.com/company">Company</FooterLink>
-      </div>
+        <FooterLink href="https://deno.land/translations">
+          Translations
+        </FooterLink>
+        <FooterLink href="https://status.deno.land/">System Status</FooterLink>
+        <FooterLink href="https://github.com/denoland/deno/wiki#companies-interested-in-deno">
+          Companies interested in Deno
+        </FooterLink>
+      </nav>
     </footer>
   );
 }
 
 function Header() {
   return (
-    <header
-      class={tw
-        `px(3 lg:14) h(12 lg:20) text-gray-500 flex justify-between items-center`}
-    >
-      <a class={tw`flex items-center flex-shrink-0`} href="/">
-        <Logo />
-        <span class={tw`ml-4 text(2xl gray-900) font-bold`}>Deno</span>
-      </a>
-      <div class={tw`flex items-center gap-6`}>
-        <NavLink href="https://deno.land/">CLI</NavLink>
-        <NavLink href="https://deno.com/blog">Blog</NavLink>
-        <NavLink href="https://deno.com/deploy">Deploy</NavLink>
-      </div>
+    <header class={tw`bg-gray-50 border-b border-gray-200 relative py-6 z-10`}>
+      <nav
+        class={tw
+          `mx-auto flex flex-wrap items-center justify-between px-4 sm:px-6 md:px-8 lg:p-0 max-w-screen-lg ${nav}`}
+      >
+        <a href="/" class={tw`flex items-center`}>
+          <Logo />
+        </a>
+        <input
+          type="checkbox"
+          id="nav-cb"
+          class={`nav-cb ${tw`hidden`}`}
+          aria-label="Navigation"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-controls="menu"
+        />
+        <div class={tw`-mr-2 flex items-center md:hidden`}>
+          <label
+            for="nav-cb"
+            class={tw
+              `inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:(text-gray-500 bg-gray-100) focus:(outline-none bg-gray-100 text-gray-500)`}
+          >
+            <svg
+              stroke="currentColor"
+              fill="none"
+              viewBox="0 0 24 24"
+              class={`menu ${tw`h-6 w-6`}`}
+            >
+              <title>Menu | Deno</title>
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h7"
+              >
+              </path>
+            </svg>
+            <svg
+              class={`close ${tw`h-6 w-6 hidden`}`}
+              stroke="currentColor"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <title>Close Menu | Deno</title>
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              >
+              </path>
+            </svg>
+          </label>
+        </div>
+        <div
+          class={`nav ${tw`md:(flex w-auto) hidden w-screen px-2 pt-4 pb-3`}`}
+        >
+          <NavLink href="https://deno.com/deploy">Deploy</NavLink>
+          <NavLink href="https://deno.land/manual">Manual</NavLink>
+          <NavLink href="https://deno.com/blog">Blog</NavLink>
+          <NavLink href="/deno/stable">API</NavLink>
+          <NavLink href="https://deno.land/std">Standard Library</NavLink>
+          <NavLink href="https://deno.land/x">Third Party Modules</NavLink>
+        </div>
+      </nav>
     </header>
   );
 }
@@ -56,8 +118,7 @@ function Logo() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="28"
-      height="28"
+      class={tw`h-10 w-auto sm:h-12 my-2`}
       viewBox="0 0 512 512"
     >
       <title>Deno logo</title>
@@ -88,8 +149,25 @@ function Logo() {
 
 const NavLink = (
   { children, href }: { children?: unknown; href: string },
-) => <a href={href} class={tw`hover:underline`}>{children}</a>;
+) => (
+  <a
+    class={tw
+      `block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:(text-gray-900 bg-gray-50) focus:(outline-none text-gray-900 bg-gray-50) md:(inline-block font-medium text-gray-500)`}
+    href={href}
+  >
+    {children}
+  </a>
+);
 
 const FooterLink = (
   { children, href }: { children?: unknown; href: string },
-) => <a href={href} class={tw`text-gray-500 hover:underline`}>{children}</a>;
+) => (
+  <div class={tw`p-2`}>
+    <a
+      class={tw`text-base leading-6 text-gray-500 hover:text-gray-900`}
+      href={href}
+    >
+      {children}
+    </a>
+  </div>
+);

--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -268,7 +268,10 @@ export function DocPage(
     return (
       <div class={gtw("content")}>
         <DocMeta base={base} url={url} doc={jsDoc?.doc ?? ""} item={item} />
-        <nav class={tw`p-6 sm:py-12 md:border-r md:border-gray-200`}>
+        <nav
+          class={tw
+            `p-6 bg-gray-100 border-b border-gray-300 sm:py-12 lg:(bg-transparent border-b-0 border-r border-gray-200)`}
+        >
           <SideBarHeader>{url}</SideBarHeader>
           <DocToc>{nodes}</DocToc>
         </nav>
@@ -330,13 +333,13 @@ function SideBarHeader({ children }: { children: Child<string> }) {
     }
     return (
       <div>
-        <h2 class={tw`text-gray-900 text-2xl font-bold`}>
+        <h2 class={tw`text-gray-900 text-xl lg:text-2xl font-bold`}>
           <a href={href} class={tw`hover:underline`}>
             {title}
           </a>
         </h2>
         {subtitle && (
-          <h3 class={tw`text-gray-900 text-xl font-bold`}>{subtitle}</h3>
+          <h3 class={tw`text-gray-900 lg:text-xl font-bold`}>{subtitle}</h3>
         )}
         <h3 class={tw`text-gray-600 text-sm mt-2`}>Registry</h3>
         <p class={tw`truncate`}>{parsed.registry}</p>
@@ -373,7 +376,7 @@ function SideBarHeader({ children }: { children: Child<string> }) {
     const [label, version] = getLibWithVersion(url);
     return (
       <div>
-        <h2 class={tw`text-gray-900 text-2xl font-bold`}>
+        <h2 class={tw`text-gray-900 text-xl lg:text-2xl font-bold`}>
           <a href={href} class={tw`hover:underline break-all`}>{label}</a>
         </h2>
         {version && (
@@ -385,21 +388,4 @@ function SideBarHeader({ children }: { children: Child<string> }) {
       </div>
     );
   }
-}
-
-function SideBar(
-  { children, item, url }: {
-    children: Child<DocNodeCollection>;
-    item?: string | null;
-    url: string;
-  },
-) {
-  const collection = take(children);
-  const library = url.startsWith("deno:");
-  return (
-    <nav class={tw`p-6 sm:py-12 md:border-r md:border-gray-200`}>
-      <SideBarHeader>{url}</SideBarHeader>
-      {item ?? <ModuleToc library={library}>{collection}</ModuleToc>}
-    </nav>
-  );
 }

--- a/components/jsdoc_test.tsx
+++ b/components/jsdoc_test.tsx
@@ -20,7 +20,7 @@ Deno.test({
     };
     const Expected = () => (
       <div>
-        <div class="tw-802k6s">
+        <div class="tw-vt15iu">
           <p>some markdown here</p>
         </div>
         <div class="text-sm mx-4">
@@ -28,7 +28,7 @@ Deno.test({
             <div>
               <span class="italic">@deprecated</span>
             </div>
-            <div class="tw-1faf0jn">
+            <div class="tw-oc8r6b">
               <p>some doc</p>
             </div>
           </div>

--- a/components/specifier_form.tsx
+++ b/components/specifier_form.tsx
@@ -11,7 +11,7 @@ function DocLinks({ children }: DocLinksProps) {
   const links = children.map((child) => (
     <li>
       <a class={gtw("link")} href={`/${child}`}>
-        <code>{child}</code>
+        <code>{child.replaceAll(/(\/|\?|\.)/g, "$1&#8203;")}</code>
       </a>
     </li>
   ));
@@ -91,7 +91,7 @@ export function SpecifierForm() {
           </p>
         </div>
         <div class={tw`mt-16 space-y-6`}>
-          <h2 class={tw`text-3xl font-bold`}>About</h2>
+          <h2 class={tw`text-2xl lg:text-3xl font-bold`}>About</h2>
           <p>
             The source for this web application is available at{" "}
             <a
@@ -107,7 +107,7 @@ export function SpecifierForm() {
             It can also be{" "}
             <a
               class={tw
-                `transition focus-visible:ring-2 focus-visible:ring-black focus:outline-none my-1 py-2 px-2.5 text-base text-gray-600 border border-gray-300 rounded-xl hover:shadow hidden lg:inline h-full`}
+                `transition focus-visible:ring-2 focus-visible:ring-black focus:outline-none my-1 py-2 px-2.5 text-base text-gray-600 border border-gray-300 rounded-xl hover:shadow h-full`}
               href={`https://dash.deno.com/new?url=${
                 encodeURIComponent(
                   "https://raw.githubusercontent.com/denoland/docland/main/main.ts",

--- a/components/styles.ts
+++ b/components/styles.ts
@@ -29,12 +29,18 @@ const buttonGradient = css({
 const code = css({
   ":not(pre) > code": apply
     `font-mono text-sm py-1 px-1.5 rounded text-black bg-gray-100`,
-  pre: apply`font-mono text-sm p-2.5 rounded-lg text-black bg-gray-100`,
+  pre: apply
+    `font-mono text-sm p-2.5 rounded-lg text-black bg-gray-100 overflow-x-auto`,
+});
+
+export const nav = css({
+  "#nav-cb:checked ~ div label .menu": apply`hidden`,
+  "#nav-cb:checked ~ div label .close, #nav-cb:checked ~ .nav": apply`block`,
 });
 
 const smallCode = css({
   ":not(pre) > code": apply`font-mono text-xs py-0.5 px-1 rounded bg-gray-100`,
-  pre: apply`font-mono text-xs p-2 my-2 rounded-lg bg-gray-100`,
+  pre: apply`font-mono text-xs p-2 my-2 rounded-lg bg-gray-100 overflow-x-auto`,
 });
 
 const none = apply``;
@@ -46,13 +52,14 @@ const baseStyles = {
   boolean: none,
   classBody: apply`flex flex-col space-y-4`,
   classMethod: none,
-  code: apply`font-mono my-4 p-3 rounded-lg bg-gray-50`,
-  content: apply`max-w-screen-xl mx-auto grid grid-cols-1 md:grid-cols-4`,
+  code: apply`font-mono my-4 p-3 rounded-lg bg-gray-50 overflow-x-auto`,
+  content: apply`max-w-screen-xl mx-auto grid grid-cols-1 lg:grid-cols-4`,
   docEntry: apply`relative px-2`,
   docItem: apply`group relative py-2 px-1`,
   docItems: apply`mt-4`,
   docSubItem: apply`group relative py-2 px-1 ml-2.5`,
-  docTitle: apply`text-4xl text-gray-900 font-bold mb-3`,
+  docTitle: apply
+    `text-2xl md:text-3xl lg:text-4xl text-gray-900 font-bold mb-3`,
   error: apply`bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mt-6`,
   formButton: apply
     `transition inline-block focus-visible:ring-2 focus-visible:ring-black focus:outline-none py-2.5 px-6 text-base text-gray-600 font-medium rounded-lg hover:shadow-lg w-full ${buttonGradient}`,
@@ -62,19 +69,20 @@ const baseStyles = {
   insideButton: apply
     `transition inline-block focus-visible:ring-2 focus-visible:ring-black focus:outline-none py-2.5 px-6 text-base text-gray-600 font-medium rounded-lg hover:shadow-lg ${buttonGradient}`,
   link: apply`hover:text-blue-800`,
-  list: apply`list-disc list-inside ml-4`,
-  main: apply`max-w-screen-md px-4 pt-16 mx-auto text-gray-900`,
+  list: apply`ml-4 list-disc list-inside`,
+  // main: apply`max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20`,
+  main: apply`max-w-screen-sm mx-auto mt-10 px-4 sm:px-6 md:(px-8 mt-20)`,
   mainBox: apply`p-6 md:col-span-3 md:p-12`,
-  mainHeader: apply`text-5xl font-bold`,
+  mainHeader: apply`text-3xl font-bold lg:text-5xl`,
   markdown: apply`ml-4 mr-2 py-2 text-sm ${smallCode}`,
   numberLiteral: none,
-  nodeClass: apply`text-green-800 mx-2 font-bold`,
-  nodeEnum: apply`text-green-700 mx-2 font-bold`,
-  nodeFunction: apply`text-cyan-800 mx-2 font-bold`,
-  nodeInterface: apply`text-cyan-900 mx-2 font-bold`,
-  nodeTypeAlias: apply`text-yellow-700 mx-2 font-bold`,
-  nodeVariable: apply`text-blue-700 mx-2 font-bold`,
-  nodeNamespace: apply`text-yellow-800 mx-2 font-bold`,
+  nodeClass: apply`text-green-800 mx-2 font-bold truncate`,
+  nodeEnum: apply`text-green-700 mx-2 font-bold truncate`,
+  nodeFunction: apply`text-cyan-800 mx-2 font-bold truncate`,
+  nodeInterface: apply`text-cyan-900 mx-2 font-bold truncate`,
+  nodeTypeAlias: apply`text-yellow-700 mx-2 font-bold truncate`,
+  nodeVariable: apply`text-blue-700 mx-2 font-bold truncate`,
+  nodeNamespace: apply`text-yellow-800 mx-2 font-bold truncate`,
   section: apply`text-2xl border-b border-gray-400 p-2 mt-1 mb-3`,
   subSection: apply`text-xl p-2 mx-2.5 mt-1 mb-2.5`,
   stringLiteral: none,

--- a/deps.ts
+++ b/deps.ts
@@ -112,14 +112,14 @@ export {
   Router,
   Status,
   STATUS_TEXT,
-} from "https://deno.land/x/oak@v10.0.0/mod.ts";
+} from "https://github.com/oakserver/oak/raw/2e76d128364c5f666873e3676dc94d64fe8e6dd2/mod.ts";
 export type {
   Context,
   Middleware,
   RouteParams,
   RouterContext,
   RouterMiddleware,
-} from "https://deno.land/x/oak@v10.0.0/mod.ts";
+} from "https://github.com/oakserver/oak/raw/2e76d128364c5f666873e3676dc94d64fe8e6dd2/mod.ts";
 
 // resvg WASM bindings that allow conversion of an SVG to a PNG. Open graph and
 // twitter do not support SVGs for card images.
@@ -155,3 +155,5 @@ export {
 } from "https://cdn.skypack.dev/-/twind@v0.16.16-LPGqCzM3XVHFUO0IDjyk/dist=es2020,mode=imports/optimized/twind/sheets.js";
 // @deno-types=https://cdn.skypack.dev/-/twind@v0.16.16-LPGqCzM3XVHFUO0IDjyk/dist=es2020,mode=types/colors/colors.d.ts
 export * as twColors from "https://cdn.skypack.dev/-/twind@v0.16.16-LPGqCzM3XVHFUO0IDjyk/dist=es2020,mode=imports/optimized/twind/colors.js";
+
+export { default as twindLogical } from "https://cdn.skypack.dev/twind-logical?dts";

--- a/shared.ts
+++ b/shared.ts
@@ -7,6 +7,7 @@ import {
   setup,
   Store,
   twColors,
+  twindLogical,
   virtualSheet,
 } from "./deps.ts";
 import type { DocNode, DocNodeNamespace } from "./deps.ts";
@@ -47,6 +48,31 @@ setup({
       purple: twColors.fuchsia,
       pink: twColors.pink,
     },
+    fontFamily: {
+      "sans": [
+        "Inter var",
+        "system-ui",
+        "Segoe UI",
+        "Roboto",
+        "Helvetica Neue",
+        "Arial",
+        "Noto Sans",
+        "sans-serif",
+      ],
+      "mono": [
+        "Menlo",
+        "Monaco",
+        "Lucida Console",
+        "Consolas",
+        "Liberation Mono",
+        "Courier New",
+        "monospace",
+      ],
+    },
+  },
+  plugins: {
+    // deno-lint-ignore no-explicit-any
+    ...(twindLogical as any),
   },
 });
 


### PR DESCRIPTION
Closes #28

An initial responsive design for the doc website.  It differs a bit from `deno.land` in that I _really_ didn't want to use client side JavaScript if I could avoid it, so the top nav hamburger is a CSS only way, and it was easier/better to "expand" out the menu instead of sort of popup.

https://user-images.githubusercontent.com/1282577/145991553-9530f91a-640e-44a4-848f-dabbedb6288d.mp4


