### PR TITLE
feat: render `@example` JSDoc tags

### DIFF
--- a/components/jsdoc_test.tsx
+++ b/components/jsdoc_test.tsx
@@ -42,3 +42,59 @@ Deno.test({
     assertEquals(actual, expected);
   },
 });
+
+Deno.test({
+  name: "JsDoc - with example tags",
+  fn() {
+    const doc = {
+      doc: "some markdown here",
+      tags: [{
+        kind: "example",
+        doc: 'const a = "a";\n',
+      }, {
+        kind: "example",
+        doc: '```ts\nconst b = "b";\n```\n',
+      }] as JsDocTagDoc[],
+    };
+    const Expected = () => (
+      <div>
+        <div class="tw-eyl7r7">
+          <p>some markdown here</p>
+        </div>
+        <div class="text-sm mx-4">
+          <div>
+            <div>
+              <span class="italic">@example</span>
+            </div>
+            <div class="tw-1p6rmm6">
+              <pre>
+                <code>
+                  <span class="code-keyword">const</span> a ={" "}
+                  <span class="code-string">"a"</span>;
+                </code>
+              </pre>
+            </div>
+          </div>
+          <div>
+            <div>
+              <span class="italic">@example</span>
+            </div>
+            <div class="tw-1p6rmm6">
+              <pre>
+                <code>
+                  <span class="code-keyword">const</span> b ={" "}
+                  <span class="code-string">"b"</span>;
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+    sheet.reset();
+    const actual = renderSSR(<JsDoc>{doc}</JsDoc>)
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected></Expected>).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});


### PR DESCRIPTION
Closes #53

This currently includes #58 and needs to be rebased when that is merged.