### PR TITLE
feat: integrate Google Analytics

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -91,6 +91,9 @@ export type {
   TsTypeUnionDef,
 } from "https://deno.land/x/deno_doc@v0.24.0/lib/types.d.ts";
 
+// Used to report measurments to Google Analytics
+export { createReportMiddleware } from "https://deno.land/x/g_a@0.1.0/mod.ts";
+
 // Used to convert lowlight trees to HTML
 export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3?pin=v58";
 

--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@ import { createBadgeMW } from "./middleware/badge.ts";
 import { handleNotFound } from "./middleware/notFound.tsx";
 import { handleErrors } from "./middleware/errors.tsx";
 import { createFaviconMW } from "./middleware/favicon.ts";
+import { ga } from "./middleware/ga.ts";
 import { logging, timing } from "./middleware/logging.ts";
 import { docGet, imgGet, pathGetHead } from "./routes/doc.tsx";
 import { indexGet } from "./routes/index.tsx";
@@ -138,6 +139,7 @@ router.get("/img/:proto(deno)/:host/~/:item+", imgGet);
 export const app = new Application();
 
 // Some general processing
+app.use(ga);
 app.use(logging);
 app.use(timing);
 app.use(createFaviconMW("https://deno.land/favicon.ico"));

--- a/middleware/ga.ts
+++ b/middleware/ga.ts
@@ -1,0 +1,17 @@
+// Copyright 2021-2022 the Deno authors. All rights reserved. MIT license.
+
+import { createReportMiddleware, STATUS_TEXT } from "../deps.ts";
+
+export const ga = createReportMiddleware({
+  metaData(ctx) {
+    let documentTitle;
+    if (!(ctx.response.status >= 200 && ctx.response.status < 300)) {
+      documentTitle = STATUS_TEXT.get(ctx.response.status)?.toLowerCase();
+    } else if (ctx.request.url.pathname === "/") {
+      documentTitle = "homepage";
+    } else {
+      documentTitle = "docpage";
+    }
+    return { documentTitle };
+  },
+});


### PR DESCRIPTION
Closes: #65 

This will require a web property ID to be provisioned in Google Analytics and added to the Deploy config before it would be active.