### PR TITLE
feat: improve package info and document title

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -219,14 +219,13 @@ export function DocPage(
   { children, base }: { children: Child<string | null | undefined>; base: URL },
 ) {
   const state = store.state as StoreState;
-  const { entries, url, includePrivate } = state;
+  let { entries, url, includePrivate } = state;
   const collection = asCollection(entries, undefined, includePrivate);
   const library = url.startsWith("deno:");
   const item = take(children);
   if (item) {
     const path = item.split(".");
     const name = path.pop()!;
-    let { entries, url } = store.state as StoreState;
     if (path && path.length) {
       const namespaces = [];
       for (const name of path) {
@@ -308,19 +307,20 @@ function SideBarHeader({ children }: { children: Child<string> }) {
       : undefined;
     let title = module;
     let subtitle;
-    if (parsed.org) {
+    const { org, package: pkg, registry, version } = parsed;
+    if (org) {
       if (module) {
-        subtitle = `${parsed.org}/${parsed.package}`;
+        subtitle = `${org}/${pkg}`;
       } else {
-        title = `${parsed.org}/${parsed.package}`;
+        title = `${org}/${pkg}`;
       }
-    } else if (parsed.package) {
+    } else if (pkg) {
       if (module) {
-        subtitle = parsed.package;
+        subtitle = pkg;
       } else {
-        title = parsed.package;
+        title = pkg;
       }
-    } else if (parsed.registry === "deno.land/std") {
+    } else if (registry === "deno.land/std") {
       subtitle = "std";
     }
     return (
@@ -338,21 +338,21 @@ function SideBarHeader({ children }: { children: Child<string> }) {
         <h3 class={tw`text-gray-600 dark:text-gray-400 text-sm mt-2`}>
           Registry
         </h3>
-        <p class={tw`truncate`}>{parsed.registry}</p>
-        {parsed.org && (
+        <p class={tw`truncate`}>{registry}</p>
+        {org && (
           <div>
             <h3 class={tw`text-gray-600 dark:text-gray-400 text-sm mt-2`}>
               Organization
             </h3>
-            <p class={tw`truncate`}>{parsed.org}</p>
+            <p class={tw`truncate`}>{org}</p>
           </div>
         )}
-        {parsed.package && (
+        {pkg && (
           <div>
             <h3 class={tw`text-gray-600 dark:text-gray-400 text-sm mt-2`}>
               Package
             </h3>
-            <p class={tw`truncate`}>{parsed.package}</p>
+            <p class={tw`truncate`}>{pkg}</p>
           </div>
         )}
         {module && (
@@ -361,6 +361,14 @@ function SideBarHeader({ children }: { children: Child<string> }) {
               Module
             </h3>
             <p class={tw`truncate`}>{module}</p>
+          </div>
+        )}
+        {version && (
+          <div>
+            <h3 class={tw`text-gray-600 dark:text-gray-400 text-sm mt-2`}>
+              Version
+            </h3>
+            <p class={tw`truncate`}>{version}</p>
           </div>
         )}
         <div>

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -63,13 +63,13 @@ Deno.test({
     const Expected = () => (
       <div class="tw-j2pie2">
         <Helmet>
-          <title>Deno Doc - example.com/mod.ts - fn</title>
+          <title>example.com/mod.ts – fn | Deno Doc</title>
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:site" content="@denoland" />
           <meta name="twitter:creator" content="@denoland" />
           <meta
             name="twitter:title"
-            content="Deno Doc - example.com/mod.ts - fn"
+            content="example.com/mod.ts – fn | Deno Doc"
           />
           <meta
             name="twitter:image"
@@ -82,7 +82,7 @@ Deno.test({
           <meta name="twitter:description" content="" />
           <meta
             property="og:title"
-            content="Deno Doc - example.com/mod.ts - fn"
+            content="example.com/mod.ts – fn | Deno Doc"
           />
           <meta
             property="og:image"

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -2,7 +2,7 @@
 /** @jsx h */
 import { h, Helmet } from "../deps.ts";
 import { getUrlLabel } from "../shared.ts";
-import { cleanMarkdown } from "../util.ts";
+import { cleanMarkdown, parseURL } from "../util.ts";
 
 export function DocMeta(
   { base, url, doc, item }: {
@@ -15,9 +15,30 @@ export function DocMeta(
   const description = cleanMarkdown(doc);
   const href = item ? `${url}${url.endsWith("/") ? "" : "/"}~/${item}` : url;
   const imageUrl = new URL(`/img/${href}`, base).toString();
-  const title = item
-    ? `Deno Doc - ${getUrlLabel(url)} - ${item}`
-    : `Deno Doc - ${getUrlLabel(url)}`;
+  const parsed = parseURL(url);
+  let title;
+  if (parsed) {
+    const { module, org, package: pkg, version, registry } = parsed;
+    const orgPkg = org ? `${org}/${pkg}` : pkg;
+    const parts = [];
+    if (module) {
+      parts.push(module);
+    }
+    if (orgPkg) {
+      parts.push(orgPkg);
+    } else if (registry === "deno.land/std") {
+      parts.push("std");
+    }
+    if (version) {
+      parts.push(`@${version}`);
+    }
+    parts.push(registry);
+    title = `${parts.join(" – ")} | Deno Doc`;
+  } else {
+    title = item
+      ? `${getUrlLabel(url)} – ${item} | Deno Doc`
+      : `${getUrlLabel(url)} | Deno Doc`;
+  }
   return (
     <Helmet>
       <title>{title}</title>

--- a/test.ts
+++ b/test.ts
@@ -48,7 +48,7 @@ Deno.test({
     assertEquals(res.status, 200);
     assertStringIncludes(
       await res.text(),
-      "<title>Deno Doc - deno/stable/</title>",
+      "<title>Deno CLI APIs | Deno Doc</title>",
     );
 
     // validate that badge.svg is available

--- a/util.ts
+++ b/util.ts
@@ -117,6 +117,10 @@ const patterns = {
       pathname: "/:org(@[^/]+)?/:pkg([^@/]+){@}?:ver?/:mod?",
       search: "*",
     }),
+    // https://cdn.skypack.dev/-/@firebase/firestore@v3.4.3-A3UEhS17OZ2Vgra7HCZF/dist=es2019,mode=types/dist/index.d.ts
+    new URLPattern(
+      "https://cdn.skypack.dev/-/:org(@[^/]+)?/:pkg([^@/]+)@:ver([^-]+):hash/:path*",
+    ),
   ],
   "unpkg.com": [
     new URLPattern(
@@ -142,8 +146,8 @@ export function parseURL(url: string): ParsedURL | undefined {
       if (match) {
         let { pathname: { groups: { regver, org, pkg, ver, mod } } } = match;
         if (registry === "gist.github.com") {
-          pkg = pkg.substr(0, 7);
-          ver = ver.substr(0, 7);
+          pkg = pkg.substring(0, 7);
+          ver = ver.substring(0, 7);
         }
         return {
           registry: regver ? `${registry} @ ${regver}` : registry,


### PR DESCRIPTION
This also includes a fix for `skypack.dev` where there was a regression because of the way we now redirect the client to any redirected URLs.