### PR TITLE
feat: support JSDoc @info tags

### DIFF
--- a/components/common.tsx
+++ b/components/common.tsx
@@ -98,6 +98,40 @@ function byName(a: [string, DocNode], b: [string, DocNode]) {
   return a[0].localeCompare(b[0]);
 }
 
+/** Given a name and the current state, attempt to calculate a link to another
+ * doc node. If it cannot be resolved, `undefined` is returned. */
+export function getLink(
+  name: string,
+  url: string,
+  entries: DocNode[],
+  namespaces: DocNodeNamespace[] = [],
+): string | undefined {
+  const ns = [...namespaces];
+  const [item, ...path] = name.split(".");
+  const anchor = path.join("_");
+  let link;
+  let namespace;
+  let namespacePath;
+  while ((namespace = ns.pop())) {
+    link = namespace.namespaceDef.elements.find((e) => e.name === item);
+    if (link) {
+      namespacePath = [...ns.map((n) => n.name), namespace.name].join(".");
+      break;
+    }
+  }
+  if (!link) {
+    link = entries.find((e) => e.name === item);
+    if (!link) {
+      return undefined;
+    }
+  }
+  const ref = (link.kind === "import" ? link.importDef.src : url);
+  const refItem = namespacePath ? `${namespacePath}.${link.name}` : link.name;
+  return `/${ref}${ref.endsWith("/") ? "" : "/"}~/${refItem}${
+    anchor && `#${anchor}`
+  }`;
+}
+
 function getName(node: DocNode, path?: string[]) {
   return path ? [...path, node.name].join(".") : node.name;
 }

--- a/components/jsdoc.tsx
+++ b/components/jsdoc.tsx
@@ -1,6 +1,8 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
 import { comrak, h, htmlEntities, lowlight, toHtml, tw } from "../deps.ts";
+import { store } from "../shared.ts";
+import type { StoreState } from "../shared.ts";
 import type {
   Accessibility,
   JsDoc as JsDocNode,
@@ -14,6 +16,7 @@ import type {
 } from "../deps.ts";
 import { assert, take } from "../util.ts";
 import type { Child } from "../util.ts";
+import { getLink } from "./common.tsx";
 import { gtw, tagMarkdownStyles } from "./styles.ts";
 import type { StyleOverride } from "./styles.ts";
 
@@ -251,6 +254,63 @@ function syntaxHighlight(html: string): string {
   return html;
 }
 
+/** Matches `{@link ...}`, `{@linkcode ...}, and `{@linkplain ...}` structures
+ * in JSDoc */
+const JSDOC_LINK_RE = /\{\s*@link(code|plain)?\s+([^}]+)}/m;
+
+/** Determines if the value looks like a relative or absolute path, or is
+ * a URI with a protocol. */
+function isLink(link: string): boolean {
+  return /^\.{0,2}\//.test(link) || /^[A-Za-z]+:\S/.test(link);
+}
+
+/** Parse out at replace `@link` tags in JSDoc to a link if possible. */
+function parseLinks(markdown: string): string {
+  let match;
+  const { url, entries, namespaces } = store.state as StoreState;
+  while ((match = JSDOC_LINK_RE.exec(markdown))) {
+    const [text, modifier, value] = match;
+    let link = value;
+    let title;
+    const indexOfSpace = value.indexOf(" ");
+    const indexOfPipe = value.indexOf("|");
+    if (indexOfPipe >= 0) {
+      link = value.slice(0, indexOfPipe);
+      title = value.slice(indexOfPipe + 1).trim();
+    } else if (indexOfSpace >= 0) {
+      link = value.slice(0, indexOfSpace);
+      title = value.slice(indexOfSpace + 1).trim();
+    }
+    const href = getLink(link, url, entries, namespaces);
+    if (href) {
+      if (!title) {
+        title = link;
+      }
+      link = href;
+    }
+    let replacement;
+    if (isLink(link)) {
+      if (title) {
+        replacement = modifier === "code"
+          ? `[\`${title}\`](${link})`
+          : `[${title}](${link})`;
+      } else {
+        replacement = modifier === "code"
+          ? `[\`${link}\`](${link})`
+          : `[${link}](${link})`;
+      }
+    } else {
+      replacement = modifier === "code"
+        ? `{_@link_ \`${link}\`${title ? ` | ${title}` : ""}}`
+        : `{_@link_ ${link}${title ? ` | ${title}` : ""}}`;
+    }
+    markdown = `${markdown.slice(0, match.index)}${replacement}${
+      markdown.slice(match.index + text.length)
+    }`;
+  }
+  return markdown;
+}
+
 export function Markdown(
   { children, style }: {
     children: Child<string | undefined>;
@@ -261,7 +321,7 @@ export function Markdown(
   return md
     ? (
       <div class={gtw("markdown", style)}>
-        {syntaxHighlight(comrak.markdownToHTML(md, {
+        {syntaxHighlight(comrak.markdownToHTML(parseLinks(md), {
           extension: {
             autolink: true,
             descriptionLists: true,

--- a/components/jsdoc.tsx
+++ b/components/jsdoc.tsx
@@ -264,7 +264,7 @@ function isLink(link: string): boolean {
   return /^\.{0,2}\//.test(link) || /^[A-Za-z]+:\S/.test(link);
 }
 
-/** Parse out at replace `@link` tags in JSDoc to a link if possible. */
+/** Parse out and replace `@link` tags in JSDoc to a link if possible. */
 function parseLinks(markdown: string): string {
   let match;
   const { url, entries, namespaces } = store.state as StoreState;

--- a/components/jsdoc_test.tsx
+++ b/components/jsdoc_test.tsx
@@ -159,7 +159,7 @@ Deno.test({
     };
     store.setState(state);
     const Expected = () => (
-      <div class="tw-av9i5b">
+      <div class="tw-15havrn">
         <p>
           Some block of test with{" "}
           <a href="/https://deno.land/x/example/mod.ts/~/A.C#C">C.C</a> and{" "}

--- a/components/jsdoc_test.tsx
+++ b/components/jsdoc_test.tsx
@@ -4,12 +4,13 @@
 import { h, renderSSR } from "../deps.ts";
 import type { JsDocTagDoc } from "../deps.ts";
 import { assertEquals } from "../deps_test.ts";
-import { sheet } from "../shared.ts";
+import { sheet, store } from "../shared.ts";
+import type { StoreState } from "../shared.ts";
 
-import { JsDoc } from "./jsdoc.tsx";
+import { JsDoc, Markdown } from "./jsdoc.tsx";
 
 Deno.test({
-  name: "JsDoc - with tags",
+  name: "JSDoc - with tags",
   fn() {
     const doc = {
       doc: "some markdown here",
@@ -44,7 +45,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "JsDoc - with example tags",
+  name: "JSDoc - with example tags",
   fn() {
     const doc = {
       doc: "some markdown here",
@@ -95,6 +96,87 @@ Deno.test({
     const actual = renderSSR(<JsDoc>{doc}</JsDoc>)
       .replaceAll("\n", "");
     const expected = renderSSR(<Expected></Expected>).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Markdown - parsing JSDoc @link tags",
+  fn() {
+    const state: StoreState = {
+      entries: [{
+        kind: "variable",
+        name: "C",
+        location: {
+          filename: "https://deno.land/x/example/mod.ts",
+          line: 1,
+          col: 0,
+        },
+        variableDef: {
+          kind: "const",
+        },
+        declarationKind: "export",
+      }, {
+        kind: "variable",
+        name: "A",
+        location: {
+          filename: "https://deno.land/x/example/mod.ts",
+          line: 2,
+          col: 0,
+        },
+        variableDef: {
+          kind: "var",
+        },
+        declarationKind: "export",
+      }],
+      namespaces: [{
+        kind: "namespace",
+        namespaceDef: {
+          elements: [{
+            kind: "variable",
+            name: "C",
+            location: {
+              filename: "https://deno.land/x/example/mod.ts",
+              line: 3,
+              col: 0,
+            },
+            variableDef: {
+              kind: "const",
+            },
+            declarationKind: "export",
+          }],
+        },
+        name: "A",
+        location: {
+          filename: "https://deno.land/x/example/mod.ts",
+          line: 2,
+          col: 0,
+        },
+        declarationKind: "export",
+      }],
+      url: "https://deno.land/x/example/mod.ts",
+      includePrivate: false,
+    };
+    store.setState(state);
+    const Expected = () => (
+      <div class="tw-av9i5b">
+        <p>
+          Some block of test with{" "}
+          <a href="/https://deno.land/x/example/mod.ts/~/A.C#C">C.C</a> and{" "}
+          <a href="/https://deno.land/x/example/mod.ts/~/A">
+            <code>A</code>
+          </a>and <a href="https://example.com/">External</a> and{" "}
+          <a href="https://example.com/">Just a Space</a>
+        </p>
+      </div>
+    );
+    sheet.reset();
+    const md = `Some block of test with {@link C.C} and {@linkcode A}
+and {@link https://example.com/ | External} and {@link https://example.com/ Just a Space}
+`;
+    const actual = renderSSR(<Markdown>{md}</Markdown>)
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
     assertEquals(actual, expected);
   },
 });

--- a/components/styles.ts
+++ b/components/styles.ts
@@ -77,7 +77,7 @@ const markdownLargeStyles = css({
   h3: apply`font-bold md:(text-lg font-normal) lg:(text-xl font-normal)`,
   h4: apply`font-semibold md:(font-bold) lg:(text-lg font-normal)`,
   h5: apply`font-italic md:(font-semibold) lg:(font-bold)`,
-  h6: apply`md:(font-italic) lg:(font-semitbold)`,
+  h6: apply`md:(font-italic) lg:(font-semibold)`,
   td: apply`p-2 border border(solid gray(500 dark:400))`,
 });
 

--- a/components/types.tsx
+++ b/components/types.tsx
@@ -41,6 +41,7 @@ import type { Child } from "../util.ts";
 import {
   Anchor,
   DocWithLink,
+  getLink,
   SectionTitle,
   SubSectionTitle,
   TocLink,
@@ -698,30 +699,10 @@ function TypeDefUnion(
 function TypeRefLink({ children }: { children: Child<string> }) {
   const name = take(children);
   const { entries, url, namespaces } = store.state as StoreState;
-  const [item, ...path] = name.split(".");
-  const anchor = path.join("_");
-  let link;
-  const ns = [...namespaces ?? []];
-  let namespace;
-  let namespacePath;
-  while ((namespace = ns.pop())) {
-    link = namespace.namespaceDef.elements.find((e) => e.name === item);
-    if (link) {
-      namespacePath = [...ns.map((n) => n.name), namespace.name].join(".");
-      break;
-    }
+  const href = getLink(name, url, entries, namespaces);
+  if (!href) {
+    return name;
   }
-  if (!link) {
-    link = entries.find((e) => e.name === item);
-    if (!link) {
-      return name;
-    }
-  }
-  const ref = (link.kind === "import" ? link.importDef.src : url);
-  const refItem = namespacePath ? `${namespacePath}.${link.name}` : link.name;
-  const href = `/${ref}${ref.endsWith("/") ? "" : "/"}~/${refItem}${
-    anchor && `#${anchor}`
-  }`;
   const so = getState(STYLE_OVERRIDE);
   return <a href={href} class={gtw("typeLink", so)}>{name}</a>;
 }


### PR DESCRIPTION
Closes #46

This supports the most "common" `@link` formats, including linking to other symbols in the doc, but it doesn't support the full complement of things supported by closure compiler (which things like the Firebase JSDocs use).  In these cases it just applies some styling to the tag.