### PR TITLE
feat: provide a usage block in a module documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: deno lint
 
       - name: 🧪  test
-        run: deno test --allow-read --allow-net --allow-env --allow-hrtime --config deno.jsonc --import-map import-map.json
+        run: deno test --allow-read --allow-net --allow-env --allow-hrtime --import-map import-map.json

--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -414,15 +414,25 @@ function SideBarHeader({ children }: { children: Child<string> }) {
   }
 }
 
+declare global {
+  interface HTMLAttributes<RefType extends EventTarget = EventTarget>
+    extends ClassAttributes<RefType> {
+    onClick?: string;
+  }
+}
+
 export function Usage({ children }: { children: Child<string> }) {
   const url = take(children);
   const parsed = parseURL(url);
   const importSymbol = camelize(parsed?.package ?? "mod");
+  const importStatement = `import * as ${importSymbol} from "${url}";\n`;
   return (
     <div>
       <h2 class={gtw("section")}>Usage</h2>
       <div class={gtw("markdown", largeMarkdownStyles)}>
         <pre>
+          {`<button class="${tw
+            `float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray(500 dark:300) border border-gray(300 dark:500) rounded hover:shadow`}" type="button" onclick="copyImportStatement()">Copy</button>`}
           <code>
             <span class="code-keyword">import</span> *{" "}
             <span class="code-keyword">as</span> {importSymbol}{" "}
@@ -431,6 +441,11 @@ export function Usage({ children }: { children: Child<string> }) {
           </code>
         </pre>
       </div>
+      <script>
+        {`function copyImportStatement() {
+          navigator.clipboard.writeText(\`${importStatement}\`);
+        }`}
+      </script>
     </div>
   );
 }

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -187,6 +187,7 @@ Deno.test({
         <h2 class="tw-17gss7d">Usage</h2>
         <div class="tw-1esk77l">
           <pre>
+            {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
             <code>
               <span class="code-keyword">import</span> *{" "}
               <span class="code-keyword">as</span> examplePackage{" "}
@@ -197,6 +198,7 @@ Deno.test({
             </code>
           </pre>
         </div>
+        {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import * as examplePackage from "https://deno.land/x/example_package/mod.ts";\`);        }</script>`}
       </div>
     );
     const actual = renderSSR(

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -6,7 +6,7 @@ import { assertEquals } from "../deps_test.ts";
 import { sheet, store } from "../shared.ts";
 import type { StoreState } from "../shared.ts";
 
-import { DocPage } from "./doc.tsx";
+import { DocPage, Usage } from "./doc.tsx";
 
 Deno.test({
   name: "DocPage - functions with other",
@@ -173,6 +173,35 @@ Deno.test({
     sheet.reset();
     const base = new URL("https://example.com/mod.ts");
     const actual = renderSSR(<DocPage base={base}>fn</DocPage>)
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Usage component",
+  fn() {
+    const Expected = () => (
+      <div>
+        <h2 class="tw-17gss7d">Usage</h2>
+        <div class="tw-1esk77l">
+          <pre>
+            <code>
+              <span class="code-keyword">import</span> *{" "}
+              <span class="code-keyword">as</span> examplePackage{" "}
+              <span class="code-keyword">from</span>{" "}
+              <span class="code-string">
+                "https://deno.land/x/example_package/mod.ts"
+              </span>;
+            </code>
+          </pre>
+        </div>
+      </div>
+    );
+    const actual = renderSSR(
+      <Usage>https://deno.land/x/example_package/mod.ts</Usage>,
+    )
       .replaceAll("\n", "");
     const expected = renderSSR(<Expected />).replaceAll("\n", "");
     assertEquals(actual, expected);

--- a/components/jsdoc.tsx
+++ b/components/jsdoc.tsx
@@ -1,6 +1,6 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
-import { comrak, h, htmlEntities, lowlight, toHtml, tw } from "../deps.ts";
+import { comrak, h, tw } from "../deps.ts";
 import { store } from "../shared.ts";
 import type { StoreState } from "../shared.ts";
 import type {
@@ -14,9 +14,9 @@ import type {
   ParamDef,
   TsTypeParamDef,
 } from "../deps.ts";
-import { assert, take } from "../util.ts";
+import { take } from "../util.ts";
 import type { Child } from "../util.ts";
-import { getLink } from "./common.tsx";
+import { getLink, syntaxHighlight } from "./common.tsx";
 import { gtw, tagMarkdownStyles } from "./styles.ts";
 import type { StyleOverride } from "./styles.ts";
 
@@ -233,25 +233,6 @@ function JsDocTag({ children }: { children: Child<JsDocTagNode> }) {
         </div>
       );
   }
-}
-
-const CODE_BLOCK_RE =
-  /<pre><code\sclass="language-([^"]+)">([^<]+)<\/code><\/pre>/m;
-
-/** Syntax highlight code blocks in an HTML string. */
-function syntaxHighlight(html: string): string {
-  let match;
-  while ((match = CODE_BLOCK_RE.exec(html))) {
-    const [text, lang, code] = match;
-    const tree = lowlight.highlight(lang, htmlEntities.decode(code), {
-      prefix: "code-",
-    });
-    assert(match.index != null);
-    html = `${html.slice(0, match.index)}<pre><code>${
-      toHtml(tree)
-    }</code></pre>${html.slice(match.index + text.length)}`;
-  }
-  return html;
 }
 
 /** Matches `{@link ...}`, `{@linkcode ...}, and `{@linkplain ...}` structures

--- a/deps.ts
+++ b/deps.ts
@@ -6,18 +6,18 @@
 import type {} from "./types.d.ts";
 
 // std library colors are used in logging to the console
-export * as colors from "https://deno.land/std@0.121.0/fmt/colors.ts";
+export * as colors from "https://deno.land/std@0.125.0/fmt/colors.ts";
 
 // WASM bindings to the comrak markdown rendering library
 export * as comrak from "https://deno.land/x/comrak@0.1.1/mod.ts";
 
 // WASM bindings to swc/deno_graph/deno_doc which generates the documentation
 // structures
-export { doc } from "https://deno.land/x/deno_doc@v0.26.1/mod.ts";
+export { doc } from "https://deno.land/x/deno_doc@v0.29.0/mod.ts";
 export type {
   DocOptions,
   LoadResponse,
-} from "https://deno.land/x/deno_doc@v0.26.1/mod.ts";
+} from "https://deno.land/x/deno_doc@v0.29.0/mod.ts";
 export type {
   Accessibility,
   ClassConstructorDef,
@@ -89,7 +89,7 @@ export type {
   TsTypeTypePredicateDef,
   TsTypeTypeRefDef,
   TsTypeUnionDef,
-} from "https://deno.land/x/deno_doc@v0.26.1/lib/types.d.ts";
+} from "https://deno.land/x/deno_doc@v0.29.0/lib/types.d.ts";
 
 // Used to report measurments to Google Analytics
 export { createReportMiddleware } from "https://deno.land/x/g_a@0.1.2/mod.ts";
@@ -97,11 +97,11 @@ export { createReportMiddleware } from "https://deno.land/x/g_a@0.1.2/mod.ts";
 // Used to convert lowlight trees to HTML
 export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3?pin=v58";
 
-// Used to do SSR of code block highlignting
+// Used to do SSR of code block highlighting
 export { lowlight } from "https://esm.sh/lowlight@2.4.1?pin=v58";
 
 // Used when overriding proxies content types when serving up static content
-export { lookup } from "https://deno.land/x/media_types@v2.11.0/mod.ts";
+export { lookup } from "https://deno.land/x/media_types@v2.12.1/mod.ts";
 
 // Importing the parts of NanoJSX which we are using in the application.
 // TODO(@kitsonk) isolate issues with > 0.0.21 and raise with NanoJSX
@@ -122,14 +122,14 @@ export {
   Router,
   Status,
   STATUS_TEXT,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@v10.2.0/mod.ts";
 export type {
   Context,
   Middleware,
   RouteParams,
   RouterContext,
   RouterMiddleware,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@v10.2.0/mod.ts";
 
 // resvg WASM bindings that allow conversion of an SVG to a PNG. Open graph and
 // twitter do not support SVGs for card images.

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -5,4 +5,4 @@ export {
   assertStringIncludes,
 } from "https://deno.land/std@0.116.0/testing/asserts.ts";
 
-export { createMockContext } from "https://deno.land/x/oak@v10.1.0/testing.ts";
+export { createMockContext } from "https://deno.land/x/oak@v10.2.0/testing.ts";

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --config deno.jsonc --import-map import-map.json --allow-read=. --allow-net --allow-env --allow-hrtime
+#!/usr/bin/env -S deno run --import-map import-map.json --allow-read=. --allow-net --allow-env --allow-hrtime
 
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 

--- a/middleware/ga.ts
+++ b/middleware/ga.ts
@@ -22,4 +22,5 @@ export function metaData(ctx: Context) {
   return { documentTitle };
 }
 
-export const ga = createReportMiddleware({ filter, metaData });
+// deno-lint-ignore no-explicit-any
+export const ga: any = createReportMiddleware({ filter, metaData } as any);

--- a/util.ts
+++ b/util.ts
@@ -161,6 +161,15 @@ export function parseURL(url: string): ParsedURL | undefined {
   }
 }
 
+/** Convert a string into a camelCased string. */
+export function camelize(str: string): string {
+  return str.split(/[\s_\-]+/).map((word, index) =>
+    index === 0
+      ? word.toLowerCase()
+      : `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`
+  ).join("");
+}
+
 /** Clean up markdown text, converting it into something that can be displayed
  * just as "normal" text. */
 export function cleanMarkdown(markdown: string): string {

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals } from "./deps_test.ts";
-import { assert, parseURL } from "./util.ts";
+import { assert, camelize, parseURL } from "./util.ts";
 
 Deno.test({
   name: "parseURL() - github raw URLs",
@@ -34,5 +34,14 @@ Deno.test({
       version: "9.4.1",
       module: "database/dist/database/index.d.ts",
     });
+  },
+});
+
+Deno.test({
+  name: "camelize",
+  fn() {
+    assertEquals(camelize("deno"), "deno");
+    assertEquals(camelize("deno_doc"), "denoDoc");
+    assertEquals(camelize("deno-graph"), "denoGraph");
   },
 });


### PR DESCRIPTION
Closes: #101

<img width="1242" alt="mod_ts_–_oak_–__v10_2_0_–_deno_land_x___Deno_Doc" src="https://user-images.githubusercontent.com/1282577/153314210-c396da3e-345e-4612-b0a6-14600c356510.png">

This also updates some of the dependencies.