### PR TITLE
feat: add import usage for individual symbols

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -1,6 +1,7 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
-import { h, tw } from "../deps.ts";
+/** @jsxFrag Fragment */
+import { Fragment, h, tw } from "../deps.ts";
 import type { DocNode, DocNodeFunction, DocNodeNamespace } from "../deps.ts";
 import { getLibWithVersion, store, StoreState } from "../shared.ts";
 import { camelize, parseURL, take } from "../util.ts";
@@ -28,6 +29,13 @@ import { NamespaceDoc, NamespaceToc } from "./namespaces.tsx";
 import { gtw, largeMarkdownStyles, largeTagStyles } from "./styles.ts";
 import { TypeAliasCodeBlock, TypeAliasDoc, TypeAliasToc } from "./types.tsx";
 import { VariableCodeBlock } from "./variables.tsx";
+
+/** For a given set of nodes, do they only contain type only nodes. */
+function isTypeOnly(nodes: DocNode[]): boolean {
+  return nodes.every((node) =>
+    node.kind === "interface" || node.kind === "typeAlias"
+  );
+}
 
 function ModuleToc(
   { children, library = false }: {
@@ -275,6 +283,9 @@ export function DocPage(
         </nav>
         <article class={gtw("mainBox")}>
           <h1 class={gtw("docTitle")}>{item}</h1>
+          {(url.endsWith(".d.ts") || library)
+            ? undefined
+            : <Usage item={item} isType={isTypeOnly(nodes)}>{url}</Usage>}
           {isAbstract(nodes[0])
             ? <Tag style={largeTagStyles} color="yellow">abstract</Tag>
             : undefined}
@@ -421,23 +432,71 @@ declare global {
   }
 }
 
-export function Usage({ children }: { children: Child<string> }) {
+export function Usage(
+  { children, item, isType }: {
+    children: Child<string>;
+    item?: string;
+    isType?: boolean;
+  },
+) {
   const url = take(children);
   const parsed = parseURL(url);
-  const importSymbol = camelize(parsed?.package ?? "mod");
-  const importStatement = `import * as ${importSymbol} from "${url}";\n`;
+  const itemParts = item?.split(".");
+  // when the imported symbol is a namespace import, we try to guess at an
+  // intelligent camelized name for the import based on the package name.  If
+  // it is a named import, we simply import the symbol itself.
+  const importSymbol = itemParts
+    ? itemParts[0]
+    : camelize(parsed?.package ?? "mod");
+  // when using a symbol from an imported namespace exported from a module, we
+  // need to create the local symbol, which we identify here.
+  const usageSymbol = itemParts && itemParts.length > 1
+    ? itemParts.pop()
+    : undefined;
+  // if it is namespaces within namespaces, we simply re-join them together
+  // instead of trying to figure out some sort of nested restructuring
+  const localVar = itemParts?.join(".");
+  // we create an import statement which is used to populate the copy paste
+  // snippet of code.
+  let importStatement = item
+    ? `import ${isType ? "type " : ""}{ ${importSymbol} } from "${url}";\n`
+    : `import * as ${importSymbol} from "${url}";\n`;
+  // if we are using a symbol off a imported namespace, we need to destructure
+  // it to a local variable.
+  if (usageSymbol) {
+    importStatement += `\nconst { ${usageSymbol} } = ${localVar};\n`;
+  }
   return (
     <div>
-      <h2 class={gtw("section")}>Usage</h2>
+      {item ? undefined : <h2 class={gtw("section")}>Usage</h2>}
       <div class={gtw("markdown", largeMarkdownStyles)}>
         <pre>
           {`<button class="${tw
             `float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray(500 dark:300) border border-gray(300 dark:500) rounded hover:shadow`}" type="button" onclick="copyImportStatement()">Copy</button>`}
           <code>
-            <span class="code-keyword">import</span> *{" "}
-            <span class="code-keyword">as</span> {importSymbol}{" "}
-            <span class="code-keyword">from</span>{" "}
-            <span class="code-string">"{url}"</span>;
+            <span class="code-keyword">import</span> {item
+              ? (
+                <>
+                  {isType
+                    ? <span class="code-keyword">type{" "}</span>
+                    : undefined}&#123; {importSymbol} &#125;
+                </>
+              )
+              : (
+                <>
+                  * <span class="code-keyword">as</span> {importSymbol}
+                </>
+              )} <span class="code-keyword">from</span>{" "}
+            <span class="code-string">"{url}"</span>;{usageSymbol
+              ? (
+                <>
+                  {" \n\n"}
+                  <span class="code-keyword">const</span> &#123; {usageSymbol}
+                  {" "}
+                  &#125; = {localVar};
+                </>
+              )
+              : undefined}
           </code>
         </pre>
       </div>

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -110,6 +110,19 @@ Deno.test({
         </nav>
         <article class="tw-baauk4">
           <h1 class="tw-d0anel">fn</h1>
+          <div>
+            <div class="tw-1esk77l">
+              <pre>
+                {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
+                <code>
+                  <span class="code-keyword">import</span> &#123; fn &#125;{" "}
+                  <span class="code-keyword">from</span>{" "}
+                  <span class="code-string">"https://example.com/mod.ts"</span>;
+                </code>
+              </pre>
+            </div>
+            {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import { fn } from "https://example.com/mod.ts";\`);        }</script>`}
+          </div>
           <div class="tw-1nkr705">
             <div>
               <span class="tw-18hyoot">function{" "}</span>
@@ -180,7 +193,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Usage component",
+  name: "Usage component - namespace import",
   fn() {
     const Expected = () => (
       <div>
@@ -203,6 +216,125 @@ Deno.test({
     );
     const actual = renderSSR(
       <Usage>https://deno.land/x/example_package/mod.ts</Usage>,
+    )
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Usage component - named import",
+  fn() {
+    const Expected = () => (
+      <div>
+        <div class="tw-1esk77l">
+          <pre>
+            {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
+            <code>
+              <span class="code-keyword">import</span> &#123; a &#125;{" "}
+              <span class="code-keyword">from</span>{" "}
+              <span class="code-string">
+                "https://deno.land/x/example_package/mod.ts"
+              </span>;
+            </code>
+          </pre>
+        </div>
+        {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import { a } from "https://deno.land/x/example_package/mod.ts";\`);        }</script>`}
+      </div>
+    );
+    const actual = renderSSR(
+      <Usage item="a">https://deno.land/x/example_package/mod.ts</Usage>,
+    )
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Usage component - named type import",
+  fn() {
+    const Expected = () => (
+      <div>
+        <div class="tw-1esk77l">
+          <pre>
+            {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
+            <code>
+              <span class="code-keyword">import</span>{" "}
+              <span class="code-keyword">type{" "}</span>&#123; A &#125;{" "}
+              <span class="code-keyword">from</span>{" "}
+              <span class="code-string">
+                "https://deno.land/x/example_package/mod.ts"
+              </span>;
+            </code>
+          </pre>
+        </div>
+        {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import type { A } from "https://deno.land/x/example_package/mod.ts";\`);        }</script>`}
+      </div>
+    );
+    const actual = renderSSR(
+      <Usage item="A" isType>https://deno.land/x/example_package/mod.ts</Usage>,
+    )
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Usage component - named namespace import",
+  fn() {
+    const Expected = () => (
+      <div>
+        <div class="tw-1esk77l">
+          <pre>
+            {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
+            <code>
+              <span class="code-keyword">import</span> &#123; a &#125;{" "}
+              <span class="code-keyword">from</span>{" "}
+              <span class="code-string">
+                "https://deno.land/x/example_package/mod.ts"
+              </span>; <span class="code-keyword">const</span>{" "}
+              &#123; b &#125; = a;
+            </code>
+          </pre>
+        </div>
+        {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import { a } from "https://deno.land/x/example_package/mod.ts";const { b } = a;\`);        }</script>`}
+      </div>
+    );
+    const actual = renderSSR(
+      <Usage item="a.b">https://deno.land/x/example_package/mod.ts</Usage>,
+    )
+      .replaceAll("\n", "");
+    const expected = renderSSR(<Expected />).replaceAll("\n", "");
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "Usage component - deep named namespace import",
+  fn() {
+    const Expected = () => (
+      <div>
+        <div class="tw-1esk77l">
+          <pre>
+            {`<button class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow" type="button" onclick="copyImportStatement()">Copy</button>`}
+            <code>
+              <span class="code-keyword">import</span> &#123; a &#125;{" "}
+              <span class="code-keyword">from</span>{" "}
+              <span class="code-string">
+                "https://deno.land/x/example_package/mod.ts"
+              </span>; <span class="code-keyword">const</span>{" "}
+              &#123; c &#125; = a.b;
+            </code>
+          </pre>
+        </div>
+        {`<script>function copyImportStatement() {          navigator.clipboard.writeText(\`import { a } from "https://deno.land/x/example_package/mod.ts";const { c } = a.b;\`);        }</script>`}
+      </div>
+    );
+    const actual = renderSSR(
+      <Usage item="a.b.c">https://deno.land/x/example_package/mod.ts</Usage>,
     )
       .replaceAll("\n", "");
     const expected = renderSSR(<Expected />).replaceAll("\n", "");

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -6,7 +6,7 @@ import { assertEquals } from "../deps_test.ts";
 import { sheet, store } from "../shared.ts";
 import type { StoreState } from "../shared.ts";
 
-import { DocPage, Usage } from "./doc.tsx";
+import { DocPage, parseUsage, Usage } from "./doc.tsx";
 
 Deno.test({
   name: "DocPage - functions with other",
@@ -339,5 +339,67 @@ Deno.test({
       .replaceAll("\n", "");
     const expected = renderSSR(<Expected />).replaceAll("\n", "");
     assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "parseUsage()",
+  fn() {
+    assertEquals(
+      parseUsage(
+        "https://deno.land/x/example_package/mod.ts",
+        undefined,
+        undefined,
+      ),
+      {
+        importStatement:
+          `import * as examplePackage from "https://deno.land/x/example_package/mod.ts";\n`,
+        importSymbol: "examplePackage",
+        localVar: undefined,
+        usageSymbol: undefined,
+      },
+    );
+    assertEquals(
+      parseUsage(
+        "https://deno.land/x/example_package/mod.ts",
+        "a",
+        undefined,
+      ),
+      {
+        importStatement:
+          `import { a } from "https://deno.land/x/example_package/mod.ts";\n`,
+        importSymbol: "a",
+        localVar: "a",
+        usageSymbol: undefined,
+      },
+    );
+    assertEquals(
+      parseUsage(
+        "https://deno.land/x/example_package/mod.ts",
+        "a.b",
+        undefined,
+      ),
+      {
+        importStatement:
+          `import { a } from "https://deno.land/x/example_package/mod.ts";\n\nconst { b } = a;\n`,
+        importSymbol: "a",
+        localVar: "a",
+        usageSymbol: "b",
+      },
+    );
+    assertEquals(
+      parseUsage(
+        "https://deno.land/x/example_package/mod.ts",
+        "a.b.c",
+        undefined,
+      ),
+      {
+        importStatement:
+          `import { a } from "https://deno.land/x/example_package/mod.ts";\n\nconst { c } = a.b;\n`,
+        importSymbol: "a",
+        localVar: "a.b",
+        usageSymbol: "c",
+      },
+    );
   },
 });


### PR DESCRIPTION
Closes: #103

For example, `serveFile` now becomes:

![http_file_server_ts_–_std_–__0_125_0_–_deno_land_std___Deno_Doc](https://user-images.githubusercontent.com/1282577/153779170-026b3b8d-e320-4e86-815f-484405f207d4.png)

