### PR TITLE
test: ensure build.ts working in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: 🧪  test
         run: deno test --allow-read --allow-net --allow-env --allow-hrtime --import-map import-map.json
+
+      - name: 🧪  test build
+        run: ./build.ts


### PR DESCRIPTION
`build.ts` is not tested in CI and it was actually found broken while releasing 1.19.3 (#115).

This PR adds a step to ensure it's working in CI and prevents the situation like the above in the future.