### PR TITLE
fix: copy button onclick

### DIFF
--- a/components/doc.tsx
+++ b/components/doc.tsx
@@ -508,14 +508,15 @@ export function Usage(
       {item ? undefined : <h2 class={gtw("section")}>Usage</h2>}
       <div class={gtw("markdown", largeMarkdownStyles)}>
         <pre>
-          <button
-            class={tw
-              `float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray(500 dark:300) border border-gray(300 dark:500) rounded hover:shadow`}
-            type="button"
-            onclick="copyImportStatement()"
+          <span
+            innerHTML={{
+              __dangerousHtml: `<button
+                class="${tw
+                `float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray(500 dark:300) border border-gray(300 dark:500) rounded hover:shadow`}"
+                type="button" onclick="copyImportStatement()">Copy</button>`,
+            }}
           >
-            Copy
-          </button>
+          </span>
           <code>
             <span class="code-keyword">import</span> {item
               ? (

--- a/components/doc_test.tsx
+++ b/components/doc_test.tsx
@@ -113,13 +113,12 @@ Deno.test({
           <div>
             <div class="tw-1esk77l">
               <pre>
-                <button
-                  class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-                  type="button"
-                  onclick="copyImportStatement()"
-                >
-                  Copy
-                </button>
+                <span
+                  innerHTML={{
+                    __dangerousHtml:
+                      `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+                  }}
+                />
                 <code>
                   <span class="code-keyword">import</span> &#123; fn &#125;{" "}
                   <span class="code-keyword">from</span>{" "}
@@ -208,13 +207,12 @@ Deno.test({
         <h2 class="tw-17gss7d">Usage</h2>
         <div class="tw-1esk77l">
           <pre>
-            <button
-              class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-              type="button"
-              onclick="copyImportStatement()"
-            >
-              Copy
-            </button>
+            <span
+              innerHTML={{
+                __dangerousHtml:
+                  `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+              }}
+            />
             <code>
               <span class="code-keyword">import</span> *{" "}
               <span class="code-keyword">as</span> examplePackage{" "}
@@ -246,13 +244,12 @@ Deno.test({
       <div>
         <div class="tw-1esk77l">
           <pre>
-            <button
-              class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-              type="button"
-              onclick="copyImportStatement()"
-            >
-              Copy
-            </button>
+            <span
+              innerHTML={{
+                __dangerousHtml:
+                  `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+              }}
+            />
             <code>
               <span class="code-keyword">import</span> &#123; a &#125;{" "}
               <span class="code-keyword">from</span>{" "}
@@ -283,13 +280,12 @@ Deno.test({
       <div>
         <div class="tw-1esk77l">
           <pre>
-            <button
-              class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-              type="button"
-              onclick="copyImportStatement()"
-            >
-              Copy
-            </button>
+            <span
+              innerHTML={{
+                __dangerousHtml:
+                  `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+              }}
+            />
             <code>
               <span class="code-keyword">import</span>{" "}
               <span class="code-keyword">type{" "}</span>&#123; A &#125;{" "}
@@ -321,13 +317,12 @@ Deno.test({
       <div>
         <div class="tw-1esk77l">
           <pre>
-            <button
-              class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-              type="button"
-              onclick="copyImportStatement()"
-            >
-              Copy
-            </button>
+            <span
+              innerHTML={{
+                __dangerousHtml:
+                  `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+              }}
+            />
             <code>
               <span class="code-keyword">import</span> &#123; a &#125;{" "}
               <span class="code-keyword">from</span>{" "}
@@ -359,13 +354,12 @@ Deno.test({
       <div>
         <div class="tw-1esk77l">
           <pre>
-            <button
-              class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"
-              type="button"
-              onclick="copyImportStatement()"
-            >
-              Copy
-            </button>
+            <span
+              innerHTML={{
+                __dangerousHtml:
+                  `<button                class="float-right px-2 font-sans focus-visible:ring-2 text-sm text-gray-500 dark:text-gray-300 border border-gray-300 dark:border-gray-500 rounded hover:shadow"                type="button" onclick="copyImportStatement()">Copy</button>`,
+              }}
+            />
             <code>
               <span class="code-keyword">import</span> &#123; a &#125;{" "}
               <span class="code-keyword">from</span>{" "}


### PR DESCRIPTION
With the upgrade to Nano JSX, the refactor of the the button code did not actually set the on click handler.  This fixes that issue.