### PR TITLE
feat: restructure module index pages

### DIFF
--- a/components/common.tsx
+++ b/components/common.tsx
@@ -18,7 +18,8 @@ import { assert, take } from "../util.ts";
 import type { Child } from "../util.ts";
 import { store } from "../shared.ts";
 import type { StoreState } from "../shared.ts";
-import { isDeprecated, JsDoc, Tag } from "./jsdoc.tsx";
+import { isDeprecated, Tag } from "./jsdoc.tsx";
+import { getDocSummary, MarkdownSummary } from "./markdown.tsx";
 import { gtw } from "./styles.ts";
 import type { BaseStyles } from "./styles.ts";
 
@@ -183,16 +184,20 @@ function Entry<Node extends DocNode>(
 ) {
   const [label, node] = take(children);
   return (
-    <li>
-      <h3 class={gtw(style)}>
-        <NodeLink>{label}</NodeLink>
-        {isAbstract(node) ? <Tag color="yellow">abstract</Tag> : undefined}
-        {isDeprecated(node.jsDoc)
-          ? <Tag color="gray">deprecated</Tag>
-          : undefined}
-      </h3>
-      <JsDoc>{node.jsDoc}</JsDoc>
-    </li>
+    <tr>
+      <td class={tw`py-1 px-2 align-top`}>
+        <span class={gtw(style)}>
+          <NodeLink>{label}</NodeLink>
+          {isAbstract(node) ? <Tag color="yellow">abstract</Tag> : undefined}
+          {isDeprecated(node.jsDoc)
+            ? <Tag color="gray">deprecated</Tag>
+            : undefined}
+        </span>
+      </td>
+      <td class={tw`py-1 px-2 align-top`}>
+        <MarkdownSummary>{getDocSummary(node)}</MarkdownSummary>
+      </td>
+    </tr>
   );
 }
 
@@ -233,7 +238,7 @@ export function Section<Node extends DocNode>(
   return (
     <div>
       <SectionTitle>{title}</SectionTitle>
-      <ul>{items}</ul>
+      <table>{items}</table>
     </div>
   );
 }

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -1,6 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
-import { comrak, h } from "../deps.ts";
+import { comrak, type DocNode, h } from "../deps.ts";
 import { store, type StoreState } from "../shared.ts";
 import { type Child, take } from "../util.ts";
 import { getLink, syntaxHighlight } from "./common.tsx";
@@ -22,6 +22,14 @@ const MARKDOWN_OPTIONS: comrak.ComrakOptions = {
     tagfilter: true,
   },
 };
+
+/** Give a doc node, get only the first paragraph of the JSDoc. */
+export function getDocSummary(docNode: DocNode) {
+  if (docNode.jsDoc?.doc) {
+    const [summary] = docNode.jsDoc.doc.split("\n\n");
+    return summary;
+  }
+}
 
 /** Determines if the value looks like a relative or absolute path, or is
  * a URI with a protocol. */


### PR DESCRIPTION
Closes #130

This provides a more concise index page for modules, where the current form, with a complex module, can get difficult to navigate.  This brings it closer to the "package"/folder index page.

**Before**

![_firebase_firestore_–__v3_4_8_–_skypack_dev___Deno_Doc](https://user-images.githubusercontent.com/1282577/165671800-fdf4fb75-fc0c-41f1-815b-0c2decaca3f8.png)

**After**

![_firebase_firestore_–__v3_4_8_–_skypack_dev___Deno_Doc](https://user-images.githubusercontent.com/1282577/165671826-eab45408-e096-47ea-b3df-8768a2312c9d.png)

It also aligns the "tags" between the module index page and the package index page.