### PR TITLE
fix: footer styles, adjust error message on the not found page

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -32,7 +32,7 @@ function Footer() {
   return (
     <footer
       class={tw
-        `mt-20 max-w-screen-xl mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8`}
+        `sticky top-full mt-20 max-w-screen-xl mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8`}
     >
       <nav class={tw`-mx-5 -my-2 flex flex-wrap justify-center`}>
         <FooterLink href="https://deno.land/manual">Manual</FooterLink>
@@ -165,9 +165,7 @@ function Logo() {
   );
 }
 
-const NavLink = (
-  { children, href }: { children?: unknown; href: string },
-) => (
+const NavLink = ({ children, href }: { children?: unknown; href: string }) => (
   <a
     class={tw
       `block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:(text-gray-900 bg-gray-50) focus:(outline-none text-gray-900 bg-gray-50) md:(inline-block font-medium text-gray-500) dark:(text-gray-200 hover:(text-gray-50 bg-gray-900) focus:(text-gray-50 bg-gray-900) md:(text-gray-400))`}
@@ -177,9 +175,13 @@ const NavLink = (
   </a>
 );
 
-const FooterLink = (
-  { children, href }: { children?: unknown; href: string },
-) => (
+const FooterLink = ({
+  children,
+  href,
+}: {
+  children?: unknown;
+  href: string;
+}) => (
   <div class={tw`p-2`}>
     <a
       class={tw

--- a/middleware/notFound.tsx
+++ b/middleware/notFound.tsx
@@ -15,15 +15,11 @@ export const handleNotFound: Middleware = async (ctx, next) => {
       const page = renderSSR(
         <App>
           <ErrorBody title="Not Found">
-            The requested URL ({`<code>"${ctx.request.url}"</code>`}) was not
-            found.
+            The requested URL <code>{ctx.request.url.href}</code> was not found.
           </ErrorBody>
         </App>,
       );
-      ctx.response.body = getBody(
-        Helmet.SSR(page),
-        getStyleTag(sheet),
-      );
+      ctx.response.body = getBody(Helmet.SSR(page), getStyleTag(sheet));
     }
   }
 };


### PR DESCRIPTION
* Fixes footer position making it stick to bottom
* Adjust error message on the not found page

Before: 
![Screen Shot 2022-05-06 at 22 38 40](https://user-images.githubusercontent.com/47859603/167272356-06ae4391-f1d2-4792-83cd-f0f2faf6a1d9.png)
After:
![Screen Shot 2022-05-07 at 23 33 48](https://user-images.githubusercontent.com/47859603/167272360-3028c21d-5e42-41cf-92f4-509a581091ab.png)
