### PR TITLE
feat: add import map support for deno.land/x modules

### DIFF
--- a/components/types.tsx
+++ b/components/types.tsx
@@ -402,9 +402,7 @@ function TypeDefMapped(
 ) {
   const {
     mappedType: { readonly, typeParam, nameType, optional, tsType },
-    // TODO(@kitsonk) remove, see: https://github.com/denoland/deno_doc/issues/226
-    // deno-lint-ignore no-explicit-any
-  } = take(children) as any;
+  } = take(children);
   const so = getState(STYLE_OVERRIDE);
   return (
     <span>

--- a/deps.ts
+++ b/deps.ts
@@ -17,7 +17,7 @@ export {
   doc,
   type DocOptions,
   type LoadResponse,
-} from "https://deno.land/x/deno_doc@v0.36.0/mod.ts";
+} from "https://deno.land/x/deno_doc@v0.37.0/mod.ts";
 export type {
   Accessibility,
   ClassConstructorDef,
@@ -89,19 +89,21 @@ export type {
   TsTypeTypePredicateDef,
   TsTypeTypeRefDef,
   TsTypeUnionDef,
-} from "https://deno.land/x/deno_doc@v0.36.0/lib/types.d.ts";
+} from "https://deno.land/x/deno_doc@v0.37.0/lib/types.d.ts";
 
 // Used to report measurements to Google Analytics
 export { createReportMiddleware } from "https://deno.land/x/g_a@0.1.2/mod.ts";
 
 // Used to convert lowlight trees to HTML
-export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3?pin=v74";
+export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3?pin=v86";
 
 // Used to sanitize some output, ensuring html entities are encoded.
-export * as htmlEntities from "https://esm.sh/html-entities@2.3.2?pin=v74";
+export * as htmlEntities from "https://esm.sh/html-entities@2.3.2?pin=v86";
+
+export * as JSONC from "https://esm.sh/jsonc-parser@3.0.0?pin=v86";
 
 // Used to do SSR of code block highlighting
-export { lowlight } from "https://esm.sh/lowlight@2.4.1?pin=v74";
+export { lowlight } from "https://esm.sh/lowlight@2.4.1?pin=v86";
 
 // Used when overriding proxies content types when serving up static content
 export { lookup } from "https://deno.land/x/media_types@v2.12.3/mod.ts";
@@ -137,7 +139,7 @@ export {
 export { render } from "https://deno.land/x/resvg_wasm@0.1.0/mod.ts";
 
 // Used to strip markdown when adding to a card image.
-export { default as removeMarkdown } from "https://esm.sh/remove-markdown@v0.3.0?pin=v74";
+export { default as removeMarkdown } from "https://esm.sh/remove-markdown@v0.3.0?pin=v86";
 
 // twind provides server side rendered CSS leveraging tailwind functional
 // classes.
@@ -147,10 +149,10 @@ export {
   type Directive,
   setup,
   tw,
-} from "https://esm.sh/twind@0.16.16?pin=v74";
-export { css } from "https://esm.sh/twind@0.16.16/css?pin=v74";
+} from "https://esm.sh/twind@0.16.16?pin=v86";
+export { css } from "https://esm.sh/twind@0.16.16/css?pin=v86";
 export {
   getStyleTag,
   virtualSheet,
-} from "https://esm.sh/twind@0.16.16/sheets?pin=v74";
-export * as twColors from "https://esm.sh/twind@0.16.16/colors?pin=v74";
+} from "https://esm.sh/twind@0.16.16/sheets?pin=v86";
+export * as twColors from "https://esm.sh/twind@0.16.16/colors?pin=v86";

--- a/docs.ts
+++ b/docs.ts
@@ -193,7 +193,7 @@ export async function getImportMapSpecifier(
   if (result?.kind === "module") {
     const { specifier, content } = result;
     const configFileJson: ConfigFileJson = JSONC.parse(content);
-    if (configFileJson.importMap) {
+    if (typeof configFileJson.importMap === "string") {
       return new URL(configFileJson.importMap, specifier).toString();
     }
     return undefined;

--- a/docs.ts
+++ b/docs.ts
@@ -7,9 +7,14 @@ import {
   type DocNodeInterface,
   type DocNodeNamespace,
   httpErrors,
+  JSONC,
   type LoadResponse,
 } from "./deps.ts";
 import { assert } from "./util.ts";
+
+interface ConfigFileJson {
+  importMap?: string;
+}
 
 /** An object which represents an "index" of a library/package. */
 export interface IndexStructure {
@@ -167,6 +172,34 @@ function enqueueCheck() {
   }
 }
 
+const CONFIG_FILES = ["deno.jsonc", "deno.json"] as const;
+
+/** Given a module and version, attempt to resolve an import map specifier from
+ * a Deno configuration file. If none can be resolved, `undefined` is
+ * resolved. */
+export async function getImportMapSpecifier(
+  module: string,
+  version: string,
+): Promise<string | undefined> {
+  let result;
+  for (const configFile of CONFIG_FILES) {
+    result = await load(
+      `https://deno.land/x/${module}@${version}/${configFile}`,
+    );
+    if (result) {
+      break;
+    }
+  }
+  if (result?.kind === "module") {
+    const { specifier, content } = result;
+    const configFileJson: ConfigFileJson = JSONC.parse(content);
+    if (configFileJson.importMap) {
+      return new URL(configFileJson.importMap, specifier).toString();
+    }
+    return undefined;
+  }
+}
+
 function getDirs(path: string, packageMeta: PackageMeta) {
   if (path.endsWith("/")) {
     path = path.slice(0, -1);
@@ -185,11 +218,14 @@ function getDirs(path: string, packageMeta: PackageMeta) {
   }
 }
 
-export async function getEntries(url: string): Promise<DocNode[]> {
+export async function getEntries(
+  url: string,
+  importMap?: string,
+): Promise<DocNode[]> {
   let entries = cachedEntries.get(url);
   if (!entries) {
     try {
-      entries = mergeEntries(await doc(url, { load }));
+      entries = mergeEntries(await doc(url, { load, importMap }));
       cachedEntries.set(url, entries);
     } catch (e) {
       if (e instanceof Error) {
@@ -314,7 +350,8 @@ async function getIndexEntries(
         ? `${proto}/${host}/std@${version}${mod}`
         : `${proto}/${host}/x/${pkg}@${version}${mod}`;
       try {
-        const entries = await getEntries(url);
+        const importMap = await getImportMapSpecifier(pkg, version);
+        const entries = await getEntries(url, importMap);
         if (entries.length) {
           indexEntries.set(mod, entries);
         }

--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -18,6 +18,7 @@ import {
 import {
   checkRedirect,
   getEntries,
+  getImportMapSpecifier,
   getIndexStructure,
   getLatest,
   getPackageDescription,
@@ -160,7 +161,13 @@ export const pathGetHead = async <R extends DocRoutes>(
     );
   }
   await maybeCacheStatic(url, host);
-  const entries = await getEntries(url);
+  let importMap;
+  const maybeMatchX = path.match(RE_X_PKG);
+  if (maybeMatchX) {
+    const [, module, version] = maybeMatchX;
+    importMap = await getImportMapSpecifier(module, version);
+  }
+  const entries = await getEntries(url, importMap);
   store.setState({ entries, url, includePrivate: proto === "deno" });
   sheet.reset();
   const page = renderSSR(

--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -162,7 +162,7 @@ export const pathGetHead = async <R extends DocRoutes>(
   }
   await maybeCacheStatic(url, host);
   let importMap;
-  const maybeMatchX = path.match(RE_X_PKG);
+  const maybeMatchX = path?.match(RE_X_PKG);
   if (maybeMatchX) {
     const [, module, version] = maybeMatchX;
     importMap = await getImportMapSpecifier(module, version);


### PR DESCRIPTION
This add import map auto-detection support for deno.land/x packages.  A follow-up PR will add an import map or config file query parameter for other modules.