### PR TITLE
chore: fix permissions on create PR workflow

### DIFF
--- a/.github/workflows/update_deno.yml
+++ b/.github/workflows/update_deno.yml
@@ -26,4 +26,4 @@ jobs:
         run: |
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git config user.name "${{ github.actor }}"
-          deno task build --create-pr
+          deno run -A --check build.ts --create-pr


### PR DESCRIPTION
I just ran a test on the CI and got this (I haven't tested this locally because it's kind of CI specific)

```
error: Uncaught (in promise) PermissionDenied: Requires read access to "/home/runner/.deno/bin/git", run again with the --allow-read flag
      const result = await Deno.stat(path);
                     ^
    at async Object.stat (deno:runtime/js/30_fs.js:230:17)
    at async RealEnvironment.fileExists (https://deno.land/x/which@0.2.1/mod.ts:19:22)
    at async which (https://deno.land/x/which@0.2.1/mod.ts:66:11)
    at async resolveCommand (https://deno.land/x/dax@0.7.0/src/shell.ts:632:23)
    at async executeCommandArgs (https://deno.land/x/dax@0.7.0/src/shell.ts:530:25)
    at async executeSimpleCommand (https://deno.land/x/dax@0.7.0/src/shell.ts:517:10)
    at async executeSequentialList (https://deno.land/x/dax@0.7.0/src/shell.ts:347:20)
    at async spawn (https://deno.land/x/dax@0.7.0/src/shell.ts:336:18)
    at async parseAndSpawnCommand (https://deno.land/x/dax@0.7.0/src/command.ts:353:18)
    at async tryCreatePr (file:///home/runner/work/docland/docland/build.ts:300:3)
```