### PR TITLE
fix: URL regex for deno.land/x modules

### DIFF
--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -42,7 +42,7 @@ type ImgRoutes =
   | "/img/:proto(deno)/:host/~/:item+";
 
 const RE_STD = /^std(?:@?([^/]+))?/;
-const RE_X_PKG = /^x\/([a-zA-Z_]{3,})(?:@?([^/]+))?/;
+const RE_X_PKG = /^x\/([^@\/]{3,})(?:@?([^/]+))?/;
 
 function isPackageHost(host: string): boolean {
   return host.toLowerCase() === "deno.land";

--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -48,9 +48,9 @@ function isPackageHost(host: string): boolean {
   return host.toLowerCase() === "deno.land";
 }
 
-/** 
+/**
  * Return `true` if the index structure has "children" entries that can be
- * displayed as an index, otherwise `false`. 
+ * displayed as an index, otherwise `false`.
  */
 function hasSubEntries(indexStructure: IndexStructure, path: string): boolean {
   return [...indexStructure.entries.keys()].some((key) =>

--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -41,15 +41,17 @@ type ImgRoutes =
   | "/img/:proto(deno)/:host"
   | "/img/:proto(deno)/:host/~/:item+";
 
-const RE_STD = /^std(?:@?([^/]+))?/;
-const RE_X_PKG = /^x\/([^@\/]{3,})(?:@?([^/]+))?/;
+const RE_STD = /^std(?:@([^/]+))?/;
+const RE_X_PKG = /^x\/([a-zA-Z0-9-_.]{3,})(?:@([^/]+))?/;
 
 function isPackageHost(host: string): boolean {
   return host.toLowerCase() === "deno.land";
 }
 
-/** Return `true` if the index structure has "children" entries that can be
- * displayed as an index, otherwise `false`. */
+/** 
+ * Return `true` if the index structure has "children" entries that can be
+ * displayed as an index, otherwise `false`. 
+ */
 function hasSubEntries(indexStructure: IndexStructure, path: string): boolean {
   return [...indexStructure.entries.keys()].some((key) =>
     key.startsWith(path) && key !== path


### PR DESCRIPTION
Should fix broken documentation links for modules with numeric digits in their names. 

Currently only `a-zA-Z_` is permitted in the code, but the registry allows modules with names like https://deno.land/x/911 to be registered.

Thanks!