### PR TITLE
fix: add user-agent to outbound fetch requests

### DIFF
--- a/middleware/notFound.tsx
+++ b/middleware/notFound.tsx
@@ -1,6 +1,6 @@
 // Copyright 2021 the Deno authors. All rights reserved. MIT license.
 /** @jsx h */
-import { getStyleTag, h, Helmet, renderSSR, Status, tw } from "../deps.ts";
+import { getStyleTag, h, Helmet, renderSSR, Status } from "../deps.ts";
 import type { Middleware } from "../deps.ts";
 import { sheet } from "../shared.ts";
 import { getBody } from "../util.ts";

--- a/routes/doc.tsx
+++ b/routes/doc.tsx
@@ -21,7 +21,6 @@ import {
   getLatest,
   getPackageDescription,
   getStaticIndex,
-  type IndexStructure,
   maybeCacheStatic,
 } from "../docs.ts";
 import { sheet, store } from "../shared.ts";
@@ -44,16 +43,6 @@ const RE_X_PKG = /^x\/([a-zA-Z0-9-_.]{3,})(?:@([^/]+))?/;
 
 function isPackageHost(host: string): boolean {
   return host.toLowerCase() === "deno.land";
-}
-
-/**
- * Return `true` if the index structure has "children" entries that can be
- * displayed as an index, otherwise `false`.
- */
-function hasSubEntries(indexStructure: IndexStructure, path: string): boolean {
-  return [...indexStructure.entries.keys()].some((key) =>
-    key.startsWith(path) && key !== path
-  );
 }
 
 export const packageGetHead: RouterMiddleware<DocRoutes> = (ctx, next) => {


### PR DESCRIPTION
This commit adds a special `User-Agent` header to outbound fetch requests.

Currently the user-agent header that upstream servers see is `Deno/1.40.4` which is a common value across all requests made from deployments on Deno Deploy. Having a special user-agent in docland will help upstreams easily identify requests coming from docland.