### PR TITLE
Block ClaudeBot from crawling deployment-specific .deno.dev URLs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -235,7 +235,9 @@ const DEPLOYMENT_URL_RE =
   /^\/https?:\/{1,2}[^/]+-[a-z0-9]{8,14}\.deno\.dev(\/|$)/;
 app.use(async (ctx, next) => {
   const ua = ctx.request.headers.get("user-agent") ?? "";
-  if (ua.includes("ClaudeBot") && DEPLOYMENT_URL_RE.test(ctx.request.url.pathname)) {
+  if (
+    ua.includes("ClaudeBot") && DEPLOYMENT_URL_RE.test(ctx.request.url.pathname)
+  ) {
     ctx.response.status = 403;
     ctx.response.body =
       "Forbidden: use the main project URL instead of deployment-specific URLs.";

--- a/main.ts
+++ b/main.ts
@@ -226,6 +226,25 @@ app.use(createBadgeMW());
 app.use(handleErrors);
 app.use(handleNotFound);
 
+// Block ClaudeBot from accessing deployment-specific .deno.dev URLs via
+// doc.deno.land. Deployment-specific URLs have the form
+// <project>-<deployment_id>.deno.dev where deployment_id is an 8-12 char
+// alphanumeric string. These URLs are ephemeral duplicates of the main project
+// URL and should not be crawled.
+const DEPLOYMENT_URL_RE =
+  /^\/https?:\/{1,2}[^/]+-[a-z0-9]{8,14}\.deno\.dev(\/|$)/;
+app.use(async (ctx, next) => {
+  const ua = ctx.request.headers.get("user-agent") ?? "";
+  if (ua.includes("ClaudeBot") && DEPLOYMENT_URL_RE.test(ctx.request.url.pathname)) {
+    ctx.response.status = 403;
+    ctx.response.body =
+      "Forbidden: use the main project URL instead of deployment-specific URLs.";
+    ctx.response.type = "text";
+    return;
+  }
+  await next();
+});
+
 app.use(router.routes());
 app.use(router.allowedMethods());
 

--- a/main.ts
+++ b/main.ts
@@ -228,11 +228,11 @@ app.use(handleNotFound);
 
 // Block ClaudeBot from accessing deployment-specific .deno.dev URLs via
 // doc.deno.land. Deployment-specific URLs have the form
-// <project>-<deployment_id>.deno.dev where deployment_id is an 8-12 char
+// <project>-<deployment_id>.deno.dev where deployment_id is a 12 char
 // alphanumeric string. These URLs are ephemeral duplicates of the main project
 // URL and should not be crawled.
 const DEPLOYMENT_URL_RE =
-  /^\/https?:\/{1,2}[^/]+-[a-z0-9]{8,14}\.deno\.dev(\/|$)/;
+  /^\/https?:\/{1,2}[^/]+-[a-z0-9]{12}\.deno\.dev(\/|$)/;
 app.use(async (ctx, next) => {
   const ua = ctx.request.headers.get("user-agent") ?? "";
   if (


### PR DESCRIPTION
## Summary

- ClaudeBot has been stuck in a crawl loop on deployment-specific URLs (e.g. `aws-api-16vtt531a2w0.deno.dev`) through doc.deno.land, causing it to repeatedly fetch source files from the target project
- This generated ~140 GB of egress bandwidth charged to the `aws-api` project owner's account (~1.4M requests over 2 days, ~38k req/hour sustained)
- Adds middleware that returns 403 for ClaudeBot requests targeting deployment-specific `.deno.dev` hostnames (pattern: `<project>-<deployment_id>.deno.dev`) while still allowing access to main project URLs (e.g. `aws-api.deno.dev`)
